### PR TITLE
Add order archiving with swipeable UI for order rows

### DIFF
--- a/src/lib/archive-store.ts
+++ b/src/lib/archive-store.ts
@@ -1,0 +1,31 @@
+const STORAGE_PREFIX = 'zelto_archived_'
+
+function getStorageKey(businessId: string): string {
+  return `${STORAGE_PREFIX}${businessId}`
+}
+
+export function getArchivedOrderIds(businessId: string): Set<string> {
+  try {
+    const raw = localStorage.getItem(getStorageKey(businessId))
+    if (!raw) return new Set()
+    return new Set(JSON.parse(raw))
+  } catch {
+    return new Set()
+  }
+}
+
+export function archiveOrder(businessId: string, orderId: string): void {
+  const ids = getArchivedOrderIds(businessId)
+  ids.add(orderId)
+  localStorage.setItem(getStorageKey(businessId), JSON.stringify([...ids]))
+}
+
+export function unarchiveOrder(businessId: string, orderId: string): void {
+  const ids = getArchivedOrderIds(businessId)
+  ids.delete(orderId)
+  localStorage.setItem(getStorageKey(businessId), JSON.stringify([...ids]))
+}
+
+export function isOrderArchived(businessId: string, orderId: string): boolean {
+  return getArchivedOrderIds(businessId).has(orderId)
+}


### PR DESCRIPTION
## Summary
This PR adds the ability to archive and unarchive orders with a swipeable gesture interface. Users can now swipe left on order rows to reveal an archive/unarchive action, and archived orders can be viewed in a separate filtered view.

## Key Changes
- **New archive store module** (`src/lib/archive-store.ts`): Manages archived order state using localStorage, keyed by business ID
- **Swipeable order rows**: Implemented `SwipeableOrderRow` component using Framer Motion that:
  - Allows left-swipe gesture to reveal archive/unarchive action button
  - Snaps open/closed with spring animation
  - Closes when tapping outside the row
  - Animates out after action is triggered
- **Archive/unarchive handlers**: Added `handleArchiveOrder` and `handleUnarchiveOrder` functions that update the archive store and refresh the UI
- **Archived orders filter**: 
  - Added "Archived" filter button that appears when archived orders exist
  - Separates orders into active and archived lists
  - Shows count of archived orders in filter button
  - Metrics (total orders, total value, outstanding balance) only count active orders
- **UI improvements**:
  - Empty state message changes based on whether viewing archived or active orders
  - Archive button color is gray, unarchive button is green
  - Toast notifications confirm archive/unarchive actions

## Implementation Details
- Archive state persists across sessions using localStorage with business ID scoping
- Swipe threshold set to 80px for reliable gesture detection
- Framer Motion handles all animations with spring physics for natural feel
- Archive filter is independent of time filters; selecting a time filter automatically switches back to active orders view

https://claude.ai/code/session_01PtncSVcBacnycutDvqB4wM