### PR TITLE
Add Trust Coach and Benchmark tabs to Trust Profile

### DIFF
--- a/src/components/TrustProfileScreen.tsx
+++ b/src/components/TrustProfileScreen.tsx
@@ -12,6 +12,8 @@ import { emitDataChange } from '@/lib/data-events'
 import { consumePendingConnectionLabels } from '@/lib/pending-connection-labels'
 import { toast } from 'sonner'
 import type { BusinessEntity, BusinessDocument, Connection } from '@/lib/types'
+import { TrustCoachTab } from './trust-profile/TrustCoachTab'
+import { TrustBenchmarkTab } from './trust-profile/TrustBenchmarkTab'
 
 export type TrustProfileActionMode = 'send-request' | 'accept-request' | 'view-connection'
 export type TrustProfileAudience = 'connection-review' | 'self-profile-ready'
@@ -27,7 +29,7 @@ interface Props {
   screenMode: TrustProfileScreenMode
   connectionRequestId?: string
   connectionId?: string
-  initialTab?: 'identity' | 'docs' | 'insights'
+  initialTab?: 'identity' | 'docs' | 'insights' | 'coach' | 'benchmark'
   onBack: () => void
   onNavigateToEditBusiness?: (scrollToDocuments?: boolean) => void
   onRequestSent?: () => void
@@ -86,7 +88,7 @@ export function TrustProfileScreen({
   const { action, audience } = screenMode
   const isConnectionReview = audience === 'connection-review'
   const isSelfProfileReady = audience === 'self-profile-ready'
-  const [activeTab, setActiveTab] = useState<'identity' | 'docs' | 'insights'>(initialTab ?? 'identity')
+  const [activeTab, setActiveTab] = useState<'identity' | 'docs' | 'insights' | 'coach' | 'benchmark'>(initialTab ?? 'identity')
 
   // Data
   const [business, setBusiness] = useState<BusinessEntity | null>(null)
@@ -426,8 +428,8 @@ export function TrustProfileScreen({
       </div>
 
       {/* Tab Strip — white, immediately below dark header */}
-      <div style={{ backgroundColor: '#fff', borderBottom: '1px solid #E8ECF2', display: 'flex', flexShrink: 0 }}>
-        {(['identity', 'docs', 'insights'] as const).map(tab => (
+      <div style={{ backgroundColor: '#fff', borderBottom: '1px solid #E8ECF2', display: 'flex', flexShrink: 0, overflowX: 'auto', whiteSpace: 'nowrap' }}>
+        {(['identity', 'docs', 'insights', 'coach', 'benchmark'] as const).map(tab => (
           <button
             key={tab}
             onClick={() => setActiveTab(tab)}
@@ -441,9 +443,10 @@ export function TrustProfileScreen({
               border: 'none',
               borderBottom: activeTab === tab ? '2px solid #4A6CF7' : '2px solid transparent',
               cursor: 'pointer',
+              minWidth: 0,
             }}
           >
-            {tab === 'identity' ? 'Identity' : tab === 'docs' ? 'Docs' : 'Insights'}
+            {tab === 'identity' ? 'Identity' : tab === 'docs' ? 'Docs' : tab === 'insights' ? 'Insights' : tab === 'coach' ? 'Coach' : 'Benchmark'}
           </button>
         ))}
       </div>
@@ -856,6 +859,12 @@ export function TrustProfileScreen({
             )}
           </div>
         )}
+
+        {/* === COACH TAB === */}
+        {activeTab === 'coach' && <TrustCoachTab businessId={targetBusinessId} />}
+
+        {/* === BENCHMARK TAB === */}
+        {activeTab === 'benchmark' && <TrustBenchmarkTab businessId={targetBusinessId} />}
       </div>
 
       {/* Fixed Bottom CTA — send-request mode */}

--- a/src/components/trust-profile/TrustBenchmarkTab.tsx
+++ b/src/components/trust-profile/TrustBenchmarkTab.tsx
@@ -1,0 +1,123 @@
+import { useState, useEffect } from 'react'
+import { intelligenceEngine } from '@/lib/intelligence-engine'
+import type { BusinessBenchmark } from '@/lib/intelligence-engine'
+
+interface Props {
+  businessId: string
+}
+
+function getSentimentColor(sentiment: 'better' | 'worse' | 'same'): string {
+  if (sentiment === 'better') return '#22B573'
+  if (sentiment === 'worse') return '#E53535'
+  return '#1A1F36'
+}
+
+export function TrustBenchmarkTab({ businessId }: Props) {
+  const [benchmark, setBenchmark] = useState<BusinessBenchmark | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    intelligenceEngine.getBusinessBenchmark(businessId).then(data => {
+      setBenchmark(data)
+      setLoading(false)
+    }).catch(() => setLoading(false))
+  }, [businessId])
+
+  if (loading) {
+    return (
+      <div style={{ padding: '20px 16px' }}>
+        <p style={{ fontSize: '13px', color: '#8492A6' }}>Loading benchmark data...</p>
+      </div>
+    )
+  }
+
+  if (!benchmark) {
+    return (
+      <div style={{ padding: '20px 16px' }}>
+        <p style={{ fontSize: '13px', color: '#8492A6' }}>Unable to load benchmark data.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div style={{ padding: '20px 16px', display: 'flex', flexDirection: 'column', gap: '16px' }}>
+
+      {/* Comparison card */}
+      <div>
+        <p style={{ fontSize: '11px', fontWeight: 600, color: '#8492A6', letterSpacing: '0.6px', marginBottom: '8px' }}>
+          YOU VS ZELTO NETWORK AVERAGE
+        </p>
+        <div style={{ backgroundColor: '#fff', borderRadius: '12px', overflow: 'hidden' }}>
+          {benchmark.metrics.map((metric, idx) => (
+            <div
+              key={metric.label}
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                padding: '10px 16px',
+                borderBottom: idx < benchmark.metrics.length - 1 ? '1px solid #F2F4F8' : 'none',
+              }}
+            >
+              <span style={{ fontSize: '13px', color: '#1A1F36' }}>
+                {metric.label}
+              </span>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+                <span style={{
+                  fontSize: '15px',
+                  fontWeight: 500,
+                  color: getSentimentColor(metric.sentiment),
+                }}>
+                  {metric.yourValue}{metric.unit}
+                </span>
+                <span style={{ fontSize: '12px', color: '#8492A6' }}>
+                  avg {metric.networkAvg}{metric.unit}
+                </span>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Gaps card — only show if gaps exist */}
+      {benchmark.gaps.length > 0 && (
+        <div>
+          <p style={{ fontSize: '11px', fontWeight: 600, color: '#8492A6', letterSpacing: '0.6px', marginBottom: '8px' }}>
+            WHERE YOU'RE BEHIND
+          </p>
+          <div style={{ backgroundColor: '#fff', borderRadius: '12px', overflow: 'hidden' }}>
+            {benchmark.gaps.map((gap, idx) => (
+              <div
+                key={gap.metric}
+                style={{
+                  display: 'flex',
+                  gap: '8px',
+                  padding: '12px 16px',
+                  borderBottom: idx < benchmark.gaps.length - 1 ? '1px solid #F2F4F8' : 'none',
+                }}
+              >
+                {/* Red/amber dot */}
+                <div style={{
+                  width: 8,
+                  height: 8,
+                  borderRadius: '50%',
+                  backgroundColor: '#E53535',
+                  flexShrink: 0,
+                  marginTop: '5px',
+                }} />
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <p style={{ fontSize: '13px', color: '#1A1F36', margin: 0 }}>
+                    {gap.metric} ({gap.yourValue} vs avg {gap.avgValue})
+                  </p>
+                  <p style={{ fontSize: '11px', color: '#8492A6', margin: '2px 0 0' }}>
+                    {gap.suggestion}
+                  </p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/trust-profile/TrustCoachTab.tsx
+++ b/src/components/trust-profile/TrustCoachTab.tsx
@@ -1,0 +1,173 @@
+import { useState, useEffect } from 'react'
+import { intelligenceEngine } from '@/lib/intelligence-engine'
+import type { TrustScoreCoach } from '@/lib/intelligence-engine'
+
+interface Props {
+  businessId: string
+}
+
+const PILLAR_COLORS: Record<string, { bg: string; color: string }> = {
+  identity: { bg: '#EEF0FF', color: '#4A6CF7' },
+  activity: { bg: '#E8F8F0', color: '#22B573' },
+  tradeRecord: { bg: '#FFF4E0', color: '#EF9F27' },
+}
+
+function BadgeRing({ progress, size = 40 }: { progress: number; size?: number }) {
+  const strokeWidth = 3.5
+  const radius = (size - strokeWidth) / 2
+  const circumference = 2 * Math.PI * radius
+  const dashOffset = circumference * (1 - Math.min(1, Math.max(0, progress)))
+
+  return (
+    <svg width={size} height={size} style={{ flexShrink: 0 }}>
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        fill="none"
+        stroke="#E8ECF2"
+        strokeWidth={strokeWidth}
+      />
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        fill="none"
+        stroke="#22B573"
+        strokeWidth={strokeWidth}
+        strokeDasharray={circumference}
+        strokeDashoffset={dashOffset}
+        strokeLinecap="round"
+        transform={`rotate(-90 ${size / 2} ${size / 2})`}
+        style={{ transition: 'stroke-dashoffset 0.4s ease' }}
+      />
+    </svg>
+  )
+}
+
+function getBadgeLabel(badge: string): string {
+  if (badge === 'basic') return 'Basic'
+  if (badge === 'verified') return 'Verified'
+  if (badge === 'trusted') return 'Trusted'
+  return badge
+}
+
+export function TrustCoachTab({ businessId }: Props) {
+  const [coach, setCoach] = useState<TrustScoreCoach | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    intelligenceEngine.getTrustScoreCoach(businessId).then(data => {
+      setCoach(data)
+      setLoading(false)
+    }).catch(() => setLoading(false))
+  }, [businessId])
+
+  if (loading) {
+    return (
+      <div style={{ padding: '20px 16px' }}>
+        <p style={{ fontSize: '13px', color: '#8492A6' }}>Loading coach data...</p>
+      </div>
+    )
+  }
+
+  if (!coach) {
+    return (
+      <div style={{ padding: '20px 16px' }}>
+        <p style={{ fontSize: '13px', color: '#8492A6' }}>Unable to load coach data.</p>
+      </div>
+    )
+  }
+
+  const isAtHighest = coach.currentBadge === 'trusted'
+  const progress = isAtHighest ? 1 : (coach.currentScore / coach.nextBadgeThreshold)
+
+  // Get the top 2 actions for the tracker text
+  const topActions = coach.actions.slice(0, 2)
+  const topPointsSum = topActions.reduce((sum, a) => sum + a.estimatedPoints, 0)
+
+  return (
+    <div style={{ padding: '20px 16px', display: 'flex', flexDirection: 'column', gap: '16px' }}>
+
+      {/* Next badge tracker card */}
+      <div style={{
+        backgroundColor: '#E1F5EE',
+        border: '1px solid #A7D8C4',
+        borderRadius: '12px',
+        padding: '12px 14px',
+      }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+          <BadgeRing progress={progress} size={40} />
+          <div style={{ flex: 1, minWidth: 0 }}>
+            {isAtHighest ? (
+              <p style={{ fontSize: '13px', fontWeight: 600, color: '#1A1F36', margin: 0 }}>
+                You've reached the highest trust level. Keep maintaining your score.
+              </p>
+            ) : (
+              <>
+                <p style={{ fontSize: '13px', fontWeight: 600, color: '#1A1F36', margin: 0 }}>
+                  {coach.pointsToNextBadge} points to next badge.
+                </p>
+                <p style={{ fontSize: '12px', color: '#4A5568', margin: '2px 0 0' }}>
+                  Complete the top 2 actions below to reach {coach.nextBadgeThreshold}+ and unlock {getBadgeLabel(coach.currentBadge === 'none' ? 'basic' : coach.currentBadge === 'basic' ? 'verified' : 'trusted')}.
+                </p>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Actions card */}
+      <div>
+        <p style={{ fontSize: '11px', fontWeight: 600, color: '#8492A6', letterSpacing: '0.6px', marginBottom: '8px' }}>
+          HIGHEST IMPACT ACTIONS
+        </p>
+        <div style={{ backgroundColor: '#fff', borderRadius: '12px', overflow: 'hidden' }}>
+          {coach.actions.length === 0 ? (
+            <div style={{ padding: '24px', textAlign: 'center' }}>
+              <p style={{ fontSize: '13px', color: '#8492A6' }}>No actions available — your profile is in great shape.</p>
+            </div>
+          ) : (
+            coach.actions.map((action, idx) => {
+              const pillarColor = PILLAR_COLORS[action.pillar] ?? PILLAR_COLORS.identity
+              return (
+                <div
+                  key={idx}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'flex-start',
+                    gap: '12px',
+                    padding: '12px 16px',
+                    borderBottom: idx < coach.actions.length - 1 ? '1px solid #F2F4F8' : 'none',
+                  }}
+                >
+                  {/* Pillar icon circle */}
+                  <div style={{
+                    width: 28,
+                    height: 28,
+                    borderRadius: '50%',
+                    backgroundColor: pillarColor.bg,
+                    flexShrink: 0,
+                  }} />
+
+                  {/* Text */}
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <p style={{ fontSize: '13px', color: '#1A1F36', margin: 0 }}>
+                      {action.action}
+                    </p>
+                    <p style={{ fontSize: '11px', color: '#22B573', margin: '2px 0 0' }}>
+                      +{action.estimatedPoints}pts estimated
+                    </p>
+                    <p style={{ fontSize: '11px', color: '#8492A6', margin: '2px 0 0' }}>
+                      {action.pillar === 'identity' ? 'Identity' : action.pillar === 'activity' ? 'Activity' : 'Trade record'} · {action.subCategory}
+                    </p>
+                  </div>
+                </div>
+              )
+            })
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
This PR adds two new tabs to the Trust Profile screen: a "Coach" tab that provides personalized guidance for improving trust scores, and a "Benchmark" tab that compares business metrics against the Zelto network average.

## Key Changes

- **New TrustCoachTab component** (`src/components/trust-profile/TrustCoachTab.tsx`)
  - Displays next badge progress with a circular progress ring indicator
  - Shows points needed to reach the next trust badge level
  - Lists highest-impact actions organized by pillar (identity, activity, trade record)
  - Includes estimated points for each action to help users prioritize improvements
  - Handles loading and error states gracefully

- **New TrustBenchmarkTab component** (`src/components/trust-profile/TrustBenchmarkTab.tsx`)
  - Compares user metrics against Zelto network averages
  - Color-codes sentiment (better/worse/same) for quick visual feedback
  - Displays gaps where the business is underperforming with actionable suggestions
  - Conditionally shows gaps section only when gaps exist

- **Updated TrustProfileScreen component**
  - Extended tab navigation to include 'coach' and 'benchmark' tabs
  - Made tab strip horizontally scrollable to accommodate additional tabs
  - Updated tab labels and routing logic to handle new tabs
  - Integrated new components into the tab content area

## Implementation Details

- Both new tabs fetch data from `intelligenceEngine` on mount with proper loading/error handling
- Uses consistent styling with existing trust profile components (colors, spacing, typography)
- BadgeRing component provides animated circular progress visualization
- Pillar-based color coding maintains visual consistency with the trust score system
- Responsive design with proper text truncation and flex layouts

https://claude.ai/code/session_01SYxkUk1Z9QGxL4HAXXGXN2