### PR TITLE
Add demo account login support for @zelto.test emails

### DIFF
--- a/src/components/OTPScreen.tsx
+++ b/src/components/OTPScreen.tsx
@@ -52,6 +52,13 @@ export function OTPScreen({ email, signupData, onSuccess, onBack }: OTPScreenPro
     setIsLoading(true)
     setError(null)
     try {
+      if (email.endsWith('@zelto.test')) {
+        const { loginAsDemo } = await import('@/lib/auth')
+        const session = await loginAsDemo(email)
+        onSuccess(session.businessId)
+        return
+      }
+
       await verifyEmailOTP(email, otp)
       const session = await findOrCreateBusinessSession(email, signupData)
       onSuccess(session.businessId)

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -76,6 +76,11 @@ export async function verifyEmailOTP(email: string, token: string): Promise<void
 
 // NEW: Replaces getAuthSession() — detects the desync state
 export async function getAuthState(): Promise<AuthState> {
+  const cachedSession = getLocalAuthSessionSync()
+  if (cachedSession?.email?.endsWith('@zelto.test')) {
+    return { status: 'authenticated', session: cachedSession }
+  }
+
   const { data: { session } } = await supabaseDirect.auth.getSession()
   if (!session) return { status: 'unauthenticated' }
 
@@ -163,6 +168,21 @@ export async function findOrCreateBusinessSession(
   const session: AuthSession = {
     businessId,
     userId,
+    email,
+    createdAt: Date.now(),
+  }
+  await setAuthSession(session)
+  return session
+}
+
+export async function loginAsDemo(email: string): Promise<AuthSession> {
+  const userAccount = await dataStore.getUserAccountByEmail(email)
+  if (!userAccount || !userAccount.businessEntityId) {
+    throw new Error('Demo account not found. Run the seed SQL first.')
+  }
+  const session: AuthSession = {
+    businessId: userAccount.businessEntityId,
+    userId: userAccount.id,
     email,
     createdAt: Date.now(),
   }


### PR DESCRIPTION
## Summary
This PR adds support for demo account authentication using special `@zelto.test` email addresses. Demo accounts bypass the standard OTP verification flow and directly authenticate using pre-seeded database records.

## Key Changes
- **New `loginAsDemo()` function** in `src/lib/auth.ts`: Authenticates demo accounts by looking up the user in the database and creating an auth session without OTP verification
- **Updated `getAuthState()`**: Added caching logic to quickly return authenticated state for demo accounts with `@zelto.test` emails
- **Modified OTP verification flow** in `src/components/OTPScreen.tsx`: Detects `@zelto.test` emails and routes them through the new `loginAsDemo()` function instead of standard OTP verification

## Implementation Details
- Demo accounts require pre-seeded data in the database (enforced by error message: "Demo account not found. Run the seed SQL first.")
- The `@zelto.test` domain is used as the identifier for demo accounts
- Demo authentication is checked early in both the auth state detection and OTP verification flows for performance
- The implementation maintains the same `AuthSession` structure and `onSuccess` callback pattern as regular authentication

https://claude.ai/code/session_01CVjtr9YCAwLvFEpc3TV37h