### PR TITLE
Rename auth session variable for clarity in demo detection

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -76,9 +76,9 @@ export async function verifyEmailOTP(email: string, token: string): Promise<void
 
 // NEW: Replaces getAuthSession() — detects the desync state
 export async function getAuthState(): Promise<AuthState> {
-  const cachedSession = getLocalAuthSessionSync()
-  if (cachedSession?.email?.endsWith('@zelto.test')) {
-    return { status: 'authenticated', session: cachedSession }
+  const demoCheck = getLocalAuthSessionSync()
+  if (demoCheck?.email?.endsWith('@zelto.test')) {
+    return { status: 'authenticated', session: demoCheck }
   }
 
   const { data: { session } } = await supabaseDirect.auth.getSession()


### PR DESCRIPTION
## Summary
Improved code clarity in the `getAuthState()` function by renaming a variable to better reflect its purpose in the demo account detection logic.

## Changes
- Renamed `cachedSession` to `demoCheck` in `getAuthState()` function to more accurately describe its role in detecting demo accounts (those with `@zelto.test` email addresses)
- Updated all references to use the new variable name consistently

## Details
This is a refactoring change that improves code readability. The variable is specifically used to check if the current session belongs to a demo account before proceeding with the standard authentication flow, so the new name `demoCheck` better communicates its intent than the generic `cachedSession`.

https://claude.ai/code/session_019saFcbXvmLvvbmVjDoXFv7