### PR TITLE
Fix concentration risk card wording from "from" to "to"

### DIFF
--- a/src/components/dashboard/ConcentrationRiskCard.tsx
+++ b/src/components/dashboard/ConcentrationRiskCard.tsx
@@ -44,7 +44,7 @@ export function ConcentrationRiskCard({ risk, loading }: Props) {
           </p>
         </div>
         <p className="text-[11px] text-muted-foreground m-0 mt-1">
-          {risk.percentage}% of your {typeLabel} from 1 {connectionCount}
+          {risk.percentage}% of your {typeLabel} to 1 {connectionCount}
         </p>
         <div
           className="mt-3 rounded-full overflow-hidden"


### PR DESCRIPTION
## Summary
Updated the concentration risk card messaging to use more accurate preposition wording.

## Changes
- Changed the concentration risk description text from "% of your {typeLabel} from 1 {connectionCount}" to "% of your {typeLabel} to 1 {connectionCount}"

## Details
This change improves the clarity of the concentration risk message by using the preposition "to" instead of "from", which better conveys that the specified percentage of assets are concentrated in a single connection point. The updated wording is more grammatically correct and clearer for users understanding their portfolio concentration risk.

https://claude.ai/code/session_01Srcnpsqxq3RwrsfYj8XgTd