### PR TITLE
Replace "trust score" messaging with concrete buyer-facing metrics

### DIFF
--- a/src/components/orders/DispatchQueueView.tsx
+++ b/src/components/orders/DispatchQueueView.tsx
@@ -209,7 +209,7 @@ export function DispatchQueueView({ items, loading, onSelectOrder }: Props) {
         </span>
         <span style={{ fontSize: 12, color: '#78350f', lineHeight: 1.4 }}>
           <strong>{items.length} order{items.length !== 1 ? 's' : ''} ready to dispatch.</strong>
-          {' '}Timely dispatch improves your trust score and keeps buyers happy.
+          {' '}Timely dispatch improves your on-time dispatch rate and keeps buyers happy.
         </span>
       </div>
 
@@ -224,7 +224,7 @@ export function DispatchQueueView({ items, loading, onSelectOrder }: Props) {
             letterSpacing: '0.06em',
             margin: '0 0 10px',
           }}>
-            Dispatch now — trust score at risk
+            Dispatch now — buyers see slow response times on your profile
           </p>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
             {urgentAndHigh.map(item => (

--- a/src/lib/orders-intelligence.ts
+++ b/src/lib/orders-intelligence.ts
@@ -60,7 +60,7 @@ function buildNewOrdersInsights(orders: EnrichedOrder[], role: Role, totalOrderC
       const hours = roundHours(now - Math.min(...staleOrders.map(o => o.createdAt)))
       insights.push({
         icon: '⏱',
-        text: `${staleOrders.length} ${staleOrders.length === 1 ? 'order' : 'orders'} placed ${hours}h+ ago with no response — acceptance delay affects your trust score`,
+        text: `${staleOrders.length} ${staleOrders.length === 1 ? 'order' : 'orders'} placed ${hours}h+ ago with no response — acceptance delay affects how buyers evaluate your reliability`,
         priority: 1,
       })
     } else {
@@ -142,13 +142,13 @@ function buildAcceptedInsights(orders: EnrichedOrder[], role: Role, totalOrderCo
     if (past48h.length > 0) {
       insights.push({
         icon: '⏱',
-        text: `${past48h.length} past 48h dispatch window — trust score at risk`,
+        text: `${past48h.length} past 48h dispatch window — buyers see slow response times on your profile`,
         priority: 1,
       })
     } else if (approaching48h.length > 0) {
       insights.push({
         icon: '⏱',
-        text: `${approaching48h.length} approaching 48h threshold — dispatch soon to protect trust score`,
+        text: `${approaching48h.length} approaching 48h threshold — dispatch soon to maintain your response time average`,
         priority: 1,
       })
     }


### PR DESCRIPTION
## Summary
Updated user-facing messaging throughout the orders intelligence and dispatch queue components to replace abstract "trust score" language with concrete, buyer-visible metrics that sellers can directly influence and understand.

## Key Changes
- **Orders Intelligence**: Updated 3 insight messages to reference specific, measurable outcomes:
  - Stale orders message now mentions "how buyers evaluate your reliability" instead of "trust score"
  - Past 48h dispatch window message now states "buyers see slow response times on your profile" instead of "trust score at risk"
  - Approaching 48h threshold message now references "response time average" instead of "trust score"

- **Dispatch Queue View**: Updated 2 messages to use concrete metrics:
  - Queue summary message now mentions "on-time dispatch rate" instead of "trust score"
  - Urgent dispatch warning now states "buyers see slow response times on your profile" instead of "trust score at risk"

## Implementation Details
These changes maintain the same priority levels and alert structure while making the messaging more transparent and actionable. Sellers now understand exactly what buyers see and can measure (response times, dispatch rates) rather than relying on an opaque "trust score" concept.

https://claude.ai/code/session_01VrpTKqYKcsNPtMEJ5Wt1jD