### PR TITLE
Improve order intelligence insights with role-specific messaging

### DIFF
--- a/src/lib/orders-intelligence.ts
+++ b/src/lib/orders-intelligence.ts
@@ -204,7 +204,7 @@ function buildAcceptedInsights(orders: EnrichedOrder[], role: Role, totalOrderCo
       const top = slowSuppliers.sort((a, b) => b[1].maxHours - a[1].maxHours)[0]
       insights.push({
         icon: '⏱',
-        text: `${top[0]} has held ${top[1].count} ${top[1].count === 1 ? 'order' : 'orders'} for ${Math.round(top[1].maxHours)}h without dispatch`,
+        text: `${top[1].count} ${top[1].count === 1 ? 'order' : 'orders'} awaiting dispatch from ${top[0]} for ${Math.round(top[1].maxHours)}h`,
         priority: 1,
       })
     } else if (totalOrderCount >= 5) {
@@ -245,7 +245,7 @@ function buildDispatchedInsights(orders: EnrichedOrder[], role: Role, totalOrder
     // Cash impact
     insights.push({
       icon: '💰',
-      text: `Once delivered, ${formatInrCurrency(totalValue)} becomes collectible`,
+      text: `Once delivered, ${formatInrCurrency(totalValue)} becomes payable`,
       priority: 3,
     })
   } else {
@@ -257,6 +257,12 @@ function buildDispatchedInsights(orders: EnrichedOrder[], role: Role, totalOrder
       icon: '🚚',
       text: `${formatInrCurrency(totalValue)} in transit to ${buyerCounts.size} ${buyerCounts.size === 1 ? 'buyer' : 'buyers'}`,
       priority: 3,
+    })
+
+    insights.push({
+      icon: '💰',
+      text: `Once delivered, ${formatInrCurrency(totalValue)} becomes collectible`,
+      priority: 4,
     })
   }
 
@@ -368,41 +374,67 @@ function buildOverdueInsights(orders: EnrichedOrder[], role: Role, hasOpenIssues
   const now = Date.now()
   const totalOverdue = orders.reduce((sum, o) => sum + o.pendingAmount, 0)
 
-  // Concentration
-  if (orders.length > 1) {
-    const overdueByCo = new Map<string, number>()
-    orders.forEach(o => {
-      overdueByCo.set(o.connectionName, (overdueByCo.get(o.connectionName) || 0) + o.pendingAmount)
-    })
-    const topOverdue = [...overdueByCo.entries()].sort((a, b) => b[1] - a[1])[0]
-    const pct = Math.round((topOverdue[1] / totalOverdue) * 100)
-    if (pct > 50) {
-      insights.push({
-        icon: '📊',
-        text: `${topOverdue[0]} owes ${pct}% of total overdue — concentration risk is high`,
-        priority: 1,
-      })
-    }
-  }
-
-  // Average delay
+  // Average delay (shared calculation, role-specific language)
   const avgDelayDays = Math.round(
     orders.reduce((sum, o) => sum + (now - (o.calculatedDueDate || now)), 0) / orders.length / 86400000
   )
-  insights.push({
-    icon: '📈',
-    text: `Average delay: ${avgDelayDays} ${avgDelayDays === 1 ? 'day' : 'days'}`,
-    priority: 2,
-  })
 
-  // Disputes blocking
-  const overdueWithIssues = orders.filter(o => o.hasOpenIssue)
-  if (overdueWithIssues.length > 0) {
+  if (role === 'selling') {
+    // Concentration: which buyer owes the most
+    if (orders.length > 1) {
+      const overdueByCo = new Map<string, number>()
+      orders.forEach(o => {
+        overdueByCo.set(o.connectionName, (overdueByCo.get(o.connectionName) || 0) + o.pendingAmount)
+      })
+      const topOverdue = [...overdueByCo.entries()].sort((a, b) => b[1] - a[1])[0]
+      const pct = Math.round((topOverdue[1] / totalOverdue) * 100)
+      if (pct > 50) {
+        insights.push({
+          icon: '📊',
+          text: `${formatInrCurrency(topOverdue[1])} awaiting collection from buyer ${topOverdue[0]} — ${pct}% of total overdue`,
+          priority: 1,
+        })
+      }
+    }
+
     insights.push({
-      icon: '⚖️',
-      text: `${overdueWithIssues.length} of ${orders.length} have open disputes — payment likely blocked until resolved`,
+      icon: '📈',
+      text: `Average collection delay: ${avgDelayDays} ${avgDelayDays === 1 ? 'day' : 'days'} past terms`,
+      priority: 2,
+    })
+
+    // Disputes blocking collection
+    const overdueWithIssues = orders.filter(o => o.hasOpenIssue)
+    if (overdueWithIssues.length > 0) {
+      insights.push({
+        icon: '⚖️',
+        text: `${overdueWithIssues.length} of ${orders.length} have open disputes — collection likely blocked until resolved`,
+        priority: 1,
+      })
+    }
+  } else {
+    // Buying view
+    insights.push({
+      icon: '⚠️',
+      text: `${orders.length} ${orders.length === 1 ? 'payment' : 'payments'} overdue totalling ${formatInrCurrency(totalOverdue)} — your payments overdue`,
       priority: 1,
     })
+
+    insights.push({
+      icon: '📈',
+      text: `Average delay: ${avgDelayDays} ${avgDelayDays === 1 ? 'day' : 'days'} — longer delays affect your reliability score`,
+      priority: 2,
+    })
+
+    // Disputes blocking
+    const overdueWithIssues = orders.filter(o => o.hasOpenIssue)
+    if (overdueWithIssues.length > 0) {
+      insights.push({
+        icon: '⚖️',
+        text: `${overdueWithIssues.length} of ${orders.length} have open disputes — resolve to clear your overdue status`,
+        priority: 1,
+      })
+    }
   }
 
   return insights


### PR DESCRIPTION
## Summary
Refactored the orders intelligence module to provide more contextual and role-specific insights for sellers and buyers. Updated messaging to be clearer and more actionable, with improved prioritization of insights based on user role.

## Key Changes

- **Slow supplier messaging**: Reworded to emphasize pending orders awaiting dispatch rather than supplier blame
- **Dispatched orders cash impact**: Changed "collectible" to "payable" for the primary insight, and moved the "collectible" insight to a lower priority (4) for sellers only
- **Overdue insights refactoring**: Completely restructured to provide role-specific context:
  - **Selling role**: Focuses on buyer concentration risk, collection delays, and disputes blocking collection
  - **Buying role**: Focuses on payment obligations, reliability score impact, and dispute resolution
- **Improved language**: 
  - Concentration risk now shows specific buyer amount and percentage of total overdue
  - Collection/payment language is now role-appropriate ("collection" for sellers, "payment" for buyers)
  - Disputes messaging clarifies impact (collection blocked vs. reliability score)
  - Added context about reliability score impact for buyers

## Implementation Details

- Moved average delay calculation to shared logic before role-specific branching
- Restructured overdue insights into `if (role === 'selling')` and `else` blocks for clearer separation
- Maintained priority levels while adjusting based on role and insight type
- All insights now include context-specific language that resonates with each user role

https://claude.ai/code/session_01VpdKY3yA6VEDFNsZi4qWnx