### PR TITLE
Reorder dashboard cards to move intelligence cards below attention section

### DIFF
--- a/src/components/DashboardScreen.tsx
+++ b/src/components/DashboardScreen.tsx
@@ -269,10 +269,6 @@ export function DashboardScreen({ currentBusinessId, onNavigateToOrders, onNavig
           </div>
         </div>
 
-        <CashForecastCard forecast={cashForecast} loading={intelLoading} />
-        <CollectionPriorityCard items={collectionItems} loading={intelLoading} onTapItem={(connId) => onNavigateToConnection(connId)} />
-        <ConcentrationRiskCard risk={concentrationRisk} loading={intelLoading} />
-
         <div>
           <h2 className="text-[10px] uppercase tracking-wide text-muted-foreground/60 mb-3">
             Needs Attention
@@ -444,6 +440,10 @@ export function DashboardScreen({ currentBusinessId, onNavigateToOrders, onNavig
               )}
           </div>
         </div>
+
+        <CashForecastCard forecast={cashForecast} loading={intelLoading} />
+        <CollectionPriorityCard items={collectionItems} loading={intelLoading} onTapItem={(connId) => onNavigateToConnection(connId)} />
+        <ConcentrationRiskCard risk={concentrationRisk} loading={intelLoading} />
 
         {onNavigateToSupplierDocs && (
           <ComplianceCard


### PR DESCRIPTION
## Summary
Reorganized the layout of the DashboardScreen component by moving the intelligence-related cards (CashForecastCard, CollectionPriorityCard, and ConcentrationRiskCard) to appear after the "Needs Attention" section instead of before it.

## Changes
- Removed the three intelligence cards from their original position (after the main content section)
- Relocated them to appear after the "Needs Attention" section and its related content
- No functional changes to the cards themselves or their props

## Details
This is a pure layout reorganization that improves the information hierarchy on the dashboard by prioritizing items that need immediate attention before displaying forecast and risk analysis cards. The cards maintain all their existing functionality and data bindings.

https://claude.ai/code/session_01QhyL3TASWzPyrRBfh1GcUD