### PR TITLE
Refactor Orders tab UI: separate Insights toggle from role filters

### DIFF
--- a/src/components/OrdersScreen.tsx
+++ b/src/components/OrdersScreen.tsx
@@ -108,7 +108,7 @@ export function OrdersScreen({ currentBusinessId, onSelectOrder, initialFilter, 
   const [filterPanelOpen, setFilterPanelOpen] = useState(false)
   const [popoverTab, setPopoverTab] = useState<RoleFilter | null>(null)
   const [showPinHint, setShowPinHint] = useState(false)
-  const [activeTab, setActiveTab] = useState<'intelligence' | null>('intelligence')
+  const [activeTab, setActiveTab] = useState<'intelligence' | null>(null)
 
   // Long-press timer refs
   const pressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -361,126 +361,134 @@ export function OrdersScreen({ currentBusinessId, onSelectOrder, initialFilter, 
             Orders
           </h1>
 
-          {/* Compact pill toggle — All | Buying | Selling with long-press to pin */}
-          <div style={{
-            display: 'flex',
-            borderRadius: 999,
-            border: '0.5px solid var(--border-light)',
-            overflow: 'visible',
-            position: 'relative',
-          }}>
+          {/* Compact pill toggle — All | Buying | Selling + Insights */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+            <div style={{
+              display: 'flex',
+              borderRadius: 999,
+              border: '0.5px solid var(--border-light)',
+              overflow: 'visible',
+              position: 'relative',
+              opacity: activeTab === 'intelligence' ? 0.4 : 1,
+              transition: 'opacity 150ms',
+            }}>
+              {(['all', 'buying', 'selling'] as const).map(role => {
+                const isPinned = pinnedTab === role
+                const isActive = activeTab === null && roleFilter === role
+                return (
+                  <div
+                    key={role}
+                    style={{ position: 'relative' }}
+                  >
+                    <button
+                      onClick={() => handleRoleChange(role)}
+                      onMouseDown={() => handlePressStart(role)}
+                      onMouseUp={handlePressEnd}
+                      onMouseLeave={handlePressEnd}
+                      onTouchStart={() => handlePressStart(role)}
+                      onTouchEnd={handlePressEnd}
+                      onContextMenu={(e) => { e.preventDefault(); setPopoverTab(role) }}
+                      style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 3,
+                        padding: '5px 14px',
+                        fontSize: 12,
+                        fontWeight: isActive ? 600 : 400,
+                        border: 'none',
+                        cursor: 'pointer',
+                        background: isActive
+                          ? 'var(--text-primary)'
+                          : 'transparent',
+                        color: isActive
+                          ? 'var(--bg-card)'
+                          : 'var(--text-secondary)',
+                        transition: 'all 150ms',
+                        borderRadius: role === 'all' ? '999px 0 0 999px' : role === 'selling' ? '0 999px 999px 0' : '0',
+                        userSelect: 'none',
+                        WebkitUserSelect: 'none',
+                      }}
+                    >
+                      {isPinned && (
+                        <PinIcon color={isActive ? 'var(--bg-card)' : 'var(--text-secondary)'} />
+                      )}
+                      {role === 'all' ? 'All' : role === 'buying' ? 'Buying' : 'Selling'}
+                    </button>
+
+                    {/* Popover for this tab */}
+                    {popoverTab === role && (
+                      <div
+                        ref={popoverRef}
+                        style={{
+                          position: 'absolute',
+                          top: 'calc(100% + 6px)',
+                          right: role === 'selling' ? 0 : undefined,
+                          left: role === 'all' ? 0 : undefined,
+                          transform: role === 'buying' ? 'translateX(-25%)' : undefined,
+                          zIndex: 100,
+                          background: 'var(--bg-card)',
+                          borderRadius: 10,
+                          boxShadow: '0 4px 16px rgba(0,0,0,0.14)',
+                          border: '0.5px solid var(--border-light)',
+                          padding: '0',
+                          minWidth: 160,
+                          overflow: 'hidden',
+                        }}
+                      >
+                        <button
+                          onClick={() => isPinned ? handleRemoveDefault() : handleSetDefault(role)}
+                          style={{
+                            display: 'block',
+                            width: '100%',
+                            padding: '12px 16px',
+                            fontSize: 13,
+                            fontWeight: 500,
+                            color: 'var(--text-primary)',
+                            background: 'none',
+                            border: 'none',
+                            cursor: 'pointer',
+                            textAlign: 'left',
+                            whiteSpace: 'nowrap',
+                          }}
+                        >
+                          {isPinned ? 'Remove as default' : 'Set as default'}
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+
+            {/* Vertical divider */}
+            <div style={{
+              width: 1,
+              height: 20,
+              background: 'var(--color-border-tertiary)',
+              flexShrink: 0,
+            }} />
+
+            {/* Insights pill */}
             <button
-              onClick={() => { setActiveTab('intelligence'); setOrderFilters(EMPTY_FILTERS); setFilterPanelOpen(false) }}
+              onClick={() => { setActiveTab(activeTab === 'intelligence' ? null : 'intelligence'); setOrderFilters(EMPTY_FILTERS); setFilterPanelOpen(false) }}
               style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: 3,
-                padding: '5px 14px',
+                padding: '6px 12px',
                 fontSize: 12,
-                fontWeight: activeTab === 'intelligence' ? 600 : 400,
-                border: 'none',
+                fontWeight: 500,
+                borderRadius: 18,
+                border: activeTab === 'intelligence' ? 'none' : '0.5px solid #4A6CF7',
+                background: activeTab === 'intelligence' ? '#4A6CF7' : 'transparent',
+                color: activeTab === 'intelligence' ? '#FFFFFF' : '#4A6CF7',
                 cursor: 'pointer',
-                background: activeTab === 'intelligence'
-                  ? 'var(--text-primary)'
-                  : 'transparent',
-                color: activeTab === 'intelligence'
-                  ? 'var(--bg-card)'
-                  : 'var(--text-secondary)',
                 transition: 'all 150ms',
-                borderRadius: '999px 0 0 999px',
                 userSelect: 'none',
                 WebkitUserSelect: 'none',
                 whiteSpace: 'nowrap',
+                flexShrink: 0,
               }}
             >
-              Intelligence
+              Insights
             </button>
-            {(['all', 'buying', 'selling'] as const).map(role => {
-              const isPinned = pinnedTab === role
-              const isActive = activeTab === null && roleFilter === role
-              return (
-                <div
-                  key={role}
-                  style={{ position: 'relative' }}
-                >
-                  <button
-                    onClick={() => handleRoleChange(role)}
-                    onMouseDown={() => handlePressStart(role)}
-                    onMouseUp={handlePressEnd}
-                    onMouseLeave={handlePressEnd}
-                    onTouchStart={() => handlePressStart(role)}
-                    onTouchEnd={handlePressEnd}
-                    onContextMenu={(e) => { e.preventDefault(); setPopoverTab(role) }}
-                    style={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: 3,
-                      padding: '5px 14px',
-                      fontSize: 12,
-                      fontWeight: isActive ? 600 : 400,
-                      border: 'none',
-                      cursor: 'pointer',
-                      background: isActive
-                        ? 'var(--text-primary)'
-                        : 'transparent',
-                      color: isActive
-                        ? 'var(--bg-card)'
-                        : 'var(--text-secondary)',
-                      transition: 'all 150ms',
-                      borderRadius: role === 'selling' ? '0 999px 999px 0' : '0',
-                      userSelect: 'none',
-                      WebkitUserSelect: 'none',
-                    }}
-                  >
-                    {isPinned && (
-                      <PinIcon color={isActive ? 'var(--bg-card)' : 'var(--text-secondary)'} />
-                    )}
-                    {role === 'all' ? 'All' : role === 'buying' ? 'Buying' : 'Selling'}
-                  </button>
-
-                  {/* Popover for this tab */}
-                  {popoverTab === role && (
-                    <div
-                      ref={popoverRef}
-                      style={{
-                        position: 'absolute',
-                        top: 'calc(100% + 6px)',
-                        right: role === 'selling' ? 0 : undefined,
-                        left: role === 'all' ? 0 : undefined,
-                        transform: role === 'buying' ? 'translateX(-25%)' : undefined,
-                        zIndex: 100,
-                        background: 'var(--bg-card)',
-                        borderRadius: 10,
-                        boxShadow: '0 4px 16px rgba(0,0,0,0.14)',
-                        border: '0.5px solid var(--border-light)',
-                        padding: '0',
-                        minWidth: 160,
-                        overflow: 'hidden',
-                      }}
-                    >
-                      <button
-                        onClick={() => isPinned ? handleRemoveDefault() : handleSetDefault(role)}
-                        style={{
-                          display: 'block',
-                          width: '100%',
-                          padding: '12px 16px',
-                          fontSize: 13,
-                          fontWeight: 500,
-                          color: 'var(--text-primary)',
-                          background: 'none',
-                          border: 'none',
-                          cursor: 'pointer',
-                          textAlign: 'left',
-                          whiteSpace: 'nowrap',
-                        }}
-                      >
-                        {isPinned ? 'Remove as default' : 'Set as default'}
-                      </button>
-                    </div>
-                  )}
-                </div>
-              )
-            })}
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
Restructured the Orders screen tab navigation to separate the "Insights" (formerly "Intelligence") toggle from the role filter pills (All/Buying/Selling). The Insights button is now a standalone toggle that can be activated independently, with visual feedback showing when it's active.

## Key Changes
- Changed initial `activeTab` state from `'intelligence'` to `null` to start with role filters visible
- Reorganized the tab container layout: role filter pills are now in their own grouped section with the Insights button as a separate toggle
- Added a vertical divider between the role filters and Insights button for visual separation
- Renamed "Intelligence" button to "Insights" with updated styling (blue pill design instead of matching role filters)
- Made Insights button a true toggle: clicking it switches between active/inactive states instead of always activating
- Added opacity transition (0.4) to role filter pills when Insights tab is active, providing visual feedback that filters are temporarily disabled
- Updated Insights button styling with custom blue color (#4A6CF7) and border styling that changes based on active state
- Improved layout with flexbox gap spacing and proper alignment of all elements

## Implementation Details
- The role filter section maintains its original pill-style design with rounded corners and long-press pin functionality
- Insights toggle uses a separate blue color scheme to visually distinguish it from role filters
- Both sections are contained in a flex container with proper alignment and spacing
- The opacity change on role filters provides clear UX feedback when switching to Insights view

https://claude.ai/code/session_014Azmk7rj4pwQCoPPbaoYfT