### PR TITLE
Restrict tab visibility based on profile ownership and audience

### DIFF
--- a/src/components/TrustProfileScreen.tsx
+++ b/src/components/TrustProfileScreen.tsx
@@ -88,7 +88,13 @@ export function TrustProfileScreen({
   const { action, audience } = screenMode
   const isConnectionReview = audience === 'connection-review'
   const isSelfProfileReady = audience === 'self-profile-ready'
-  const [activeTab, setActiveTab] = useState<'identity' | 'docs' | 'insights' | 'coach' | 'benchmark'>(initialTab ?? 'identity')
+  const isOwnProfile = targetBusinessId === currentBusinessId
+  const [activeTab, setActiveTab] = useState<'identity' | 'docs' | 'insights' | 'coach' | 'benchmark'>(() => {
+    const tab = initialTab ?? 'identity'
+    if (tab === 'coach' && targetBusinessId !== currentBusinessId) return 'identity'
+    if (tab === 'insights' && audience !== 'self-profile-ready' && audience !== 'connection-review') return 'identity'
+    return tab
+  })
 
   // Data
   const [business, setBusiness] = useState<BusinessEntity | null>(null)
@@ -429,7 +435,11 @@ export function TrustProfileScreen({
 
       {/* Tab Strip — white, immediately below dark header */}
       <div style={{ backgroundColor: '#fff', borderBottom: '1px solid #E8ECF2', display: 'flex', flexShrink: 0, overflowX: 'auto', whiteSpace: 'nowrap' }}>
-        {(['identity', 'docs', 'insights', 'coach', 'benchmark'] as const).map(tab => (
+        {(['identity', 'docs', 'insights', 'coach', 'benchmark'] as const).filter(tab => {
+          if (tab === 'coach') return isOwnProfile
+          if (tab === 'insights') return isSelfProfileReady || isConnectionReview
+          return true
+        }).map(tab => (
           <button
             key={tab}
             onClick={() => setActiveTab(tab)}


### PR DESCRIPTION
## Summary
This change restricts access to certain tabs in the TrustProfileScreen based on whether the user is viewing their own profile and the intended audience. The "Coach" tab is now only visible when viewing your own profile, and the "Insights" tab is only visible for self-profile-ready and connection-review audiences.

## Key Changes
- Added `isOwnProfile` computed value to determine if the viewed profile belongs to the current user
- Updated `activeTab` state initialization to validate the initial tab against visibility rules:
  - Redirects to 'identity' tab if 'coach' tab is requested but viewing another's profile
  - Redirects to 'identity' tab if 'insights' tab is requested for unsupported audiences
- Modified tab strip rendering to filter out tabs based on visibility rules:
  - 'coach' tab only shown when `isOwnProfile` is true
  - 'insights' tab only shown for 'self-profile-ready' or 'connection-review' audiences
  - Other tabs ('identity', 'docs', 'benchmark') always visible

## Implementation Details
The tab filtering is applied at two levels:
1. **State initialization**: Ensures the active tab is valid when the component mounts
2. **UI rendering**: Filters the tab list before rendering buttons to prevent users from accessing restricted tabs

This prevents both direct navigation to restricted tabs and ensures the UI accurately reflects what tabs are available to the user.

https://claude.ai/code/session_01PAejYmMVtoV4tUCfGaca5J