### PR TITLE
Improve Trade Intelligence card labels and data display

### DIFF
--- a/src/components/DashboardScreen.tsx
+++ b/src/components/DashboardScreen.tsx
@@ -439,13 +439,18 @@ export function DashboardScreen({ currentBusinessId, onNavigateToOrders, onNavig
           </div>
         </div>
 
-        <MoneyCard
-          forecast={cashForecast}
-          collectionItems={collectionItems}
-          concentrationRisk={concentrationRisk}
-          loading={intelLoading}
-          onTapCollectionItem={(connId) => onNavigateToConnection(connId)}
-        />
+        <div>
+          <h2 className="text-[10px] uppercase tracking-wide text-muted-foreground/60 mb-3">
+            Trade Intelligence
+          </h2>
+          <MoneyCard
+            forecast={cashForecast}
+            collectionItems={collectionItems}
+            concentrationRisk={concentrationRisk}
+            loading={intelLoading}
+            onTapCollectionItem={(connId) => onNavigateToConnection(connId)}
+          />
+        </div>
 
         {onNavigateToSupplierDocs && (
           <ComplianceCard

--- a/src/components/dashboard/MoneyCard.tsx
+++ b/src/components/dashboard/MoneyCard.tsx
@@ -67,9 +67,9 @@ export function MoneyCard({ forecast, collectionItems, concentrationRisk, loadin
   }
 
   const tabs: Array<{ id: 'collect' | 'forecast' | 'risk'; label: string; count?: number }> = [
-    { id: 'collect', label: 'Collect', count: collectCount > 0 ? Math.min(collectCount, 3) : undefined },
-    { id: 'forecast', label: 'Forecast' },
-    { id: 'risk', label: 'Risk' },
+    { id: 'collect', label: 'Priority', count: collectCount > 0 ? Math.min(collectCount, 3) : undefined },
+    { id: 'forecast', label: 'Cash Forecast' },
+    { id: 'risk', label: 'Exposure' },
   ]
 
   return (
@@ -159,7 +159,7 @@ export function MoneyCard({ forecast, collectionItems, concentrationRisk, loadin
                           {item.businessName}
                         </p>
                         <p style={{ fontSize: '11px', color: '#8492A6', margin: '1px 0 0' }}>
-                          {item.onTimeCount} on-time, {item.lateCount} late in 30d
+                          {item.patternDetail}
                         </p>
                       </div>
                       <div style={{ textAlign: 'right', flexShrink: 0 }}>
@@ -167,7 +167,7 @@ export function MoneyCard({ forecast, collectionItems, concentrationRisk, loadin
                           fontSize: '14px', fontWeight: 600, margin: 0,
                           color: isOverdue ? '#E24B4A' : '#D97706',
                         }}>
-                          {formatInrCurrency(item.amount)}
+                          {formatInrCurrency(item.overdueAmount)}
                         </p>
                         <p style={{
                           fontSize: '11px', margin: '1px 0 0',
@@ -193,7 +193,7 @@ export function MoneyCard({ forecast, collectionItems, concentrationRisk, loadin
                       {formatInrCurrency(
                         collectionItems
                           .filter(item => item.daysOverdue > 0)
-                          .reduce((sum, item) => sum + item.amount, 0)
+                          .reduce((sum, item) => sum + item.overdueAmount, 0)
                       )}
                     </span>
                   </div>


### PR DESCRIPTION
## Summary
Updated the Trade Intelligence section on the Dashboard to improve clarity and consistency in labeling, and corrected data field references to use the appropriate amount fields.

## Key Changes
- Added a "Trade Intelligence" section header above the MoneyCard component with consistent styling
- Renamed tab labels for better clarity:
  - "Collect" → "Priority"
  - "Forecast" → "Cash Forecast"
  - "Risk" → "Exposure"
- Updated collection item display to show `patternDetail` instead of the on-time/late count breakdown
- Corrected amount field references from `item.amount` to `item.overdueAmount` to display the correct financial data
- Updated the overdue amount calculation to use `overdueAmount` field consistently

## Implementation Details
- The section header uses the same styling pattern as other dashboard sections (uppercase, muted text, tracking-wide)
- Tab label changes improve semantic clarity around the purpose of each view
- Data field corrections ensure the card displays overdue-specific amounts rather than total amounts

https://claude.ai/code/session_018VuSBmZBxLU2aa65gcVKLe