### PR TITLE
Add dispute indicator to order cards across all screens

### DIFF
--- a/src/components/ConnectionDetailScreen.tsx
+++ b/src/components/ConnectionDetailScreen.tsx
@@ -45,6 +45,7 @@ export function ConnectionDetailScreen({ connectionId, currentBusinessId, onBack
   const [otherBusiness, setOtherBusiness] = useState<BusinessEntity | null>(null)
   const [orders, setOrders] = useState<OrderWithPaymentState[]>([])
   const [openIssueOrderIds, setOpenIssueOrderIds] = useState<Set<string>>(new Set())
+  const [openIssueSummaryMap, setOpenIssueSummaryMap] = useState<Map<string, string>>(new Map())
   const [insights, setInsights] = useState<Insight[]>([])
   const [orderFilters, setOrderFilters] = useState<OrderFilters>(EMPTY_FILTERS)
   const [panelVisible, setPanelVisible] = useState(false)
@@ -104,11 +105,15 @@ export function ConnectionDetailScreen({ connectionId, currentBusinessId, onBack
           dataStore.getIssueReportsByOrderIds(orderIds),
         ])
         setAttachmentCounts(counts)
-        setOpenIssueOrderIds(new Set(
-          issues
-            .filter(issue => issue.status === 'Open' || issue.status === 'Acknowledged')
-            .map(issue => issue.orderId)
-        ))
+        const openIssues = issues.filter(issue => issue.status === 'Open' || issue.status === 'Acknowledged')
+        setOpenIssueOrderIds(new Set(openIssues.map(issue => issue.orderId)))
+        const summaryMap = new Map<string, string>()
+        openIssues.forEach(issue => {
+          if (!summaryMap.has(issue.orderId)) {
+            summaryMap.set(issue.orderId, issue.issueType)
+          }
+        })
+        setOpenIssueSummaryMap(summaryMap)
       }
     } catch (err) {
       console.error('Failed to load orders:', err)
@@ -498,6 +503,8 @@ export function ConnectionDetailScreen({ connectionId, currentBusinessId, onBack
                         isBuyer={isBuyer}
                         isNew={isNew}
                         isOld={isOld}
+                        hasOpenDispute={openIssueOrderIds.has(order.id)}
+                        disputeSummary={openIssueSummaryMap.get(order.id) ?? null}
                         onClick={() => {
                           markOrderSeen(currentBusinessId, order.id)
                           onOpenOrderDetail(order.id, connection.id)

--- a/src/components/DashboardScreen.tsx
+++ b/src/components/DashboardScreen.tsx
@@ -478,6 +478,8 @@ export function DashboardScreen({ currentBusinessId, onNavigateToOrders, onNavig
                   deliveredAt={order.deliveredAt}
                   latestActivity={order.latestActivity}
                   isBuyer={order.isBuyer}
+                  hasOpenDispute={order.hasOpenIssue}
+                  disputeSummary={order.openIssueSummary}
                   onClick={() => onNavigateToConnection(order.connectionId, order.id)}
                 />
               ))}

--- a/src/components/OrdersScreen.tsx
+++ b/src/components/OrdersScreen.tsx
@@ -781,7 +781,9 @@ export function OrdersScreen({ currentBusinessId, onSelectOrder, initialFilter, 
                 deliveredAt={order.deliveredAt}
                 latestActivity={order.latestActivity}
                 isBuyer={order.isBuyer}
-onClick={() => onSelectOrder(order.id, order.connectionId)}
+                hasOpenDispute={order.hasOpenIssue}
+                disputeSummary={order.openIssueSummary}
+                onClick={() => onSelectOrder(order.id, order.connectionId)}
               />
             ))}
           </div>

--- a/src/components/order/ConnectionDetailOrderCard.tsx
+++ b/src/components/order/ConnectionDetailOrderCard.tsx
@@ -16,6 +16,8 @@ export interface ConnectionDetailOrderCardProps {
   isNew: boolean
   isOld: boolean
   onClick: () => void
+  hasOpenDispute?: boolean
+  disputeSummary?: string | null
 }
 
 // ─── Half-pill helpers (mirrors OrderCard style) ─────────────────────────────
@@ -82,6 +84,8 @@ export function ConnectionDetailOrderCard({
   isNew,
   isOld,
   onClick,
+  hasOpenDispute = false,
+  disputeSummary,
 }: ConnectionDetailOrderCardProps) {
   const now = Date.now()
   const isPaid = settlementState === 'Paid'
@@ -130,9 +134,10 @@ export function ConnectionDetailOrderCard({
       className="w-full text-left"
       style={{
         backgroundColor: isNew ? 'var(--brand-primary-bg)' : 'var(--bg-card)',
-        borderRadius: 'var(--radius-card)',
+        borderRadius: hasOpenDispute ? '0 var(--radius-card) var(--radius-card) 0' : 'var(--radius-card)',
         padding: '14px 16px',
         border: '1px solid var(--border-light)',
+        borderLeft: hasOpenDispute ? '3px solid #8B5CF6' : '1px solid var(--border-light)',
         boxShadow: '0 1px 2px rgba(16,24,40,0.04)',
         opacity: lifecycleState === 'Declined' ? 0.4 : 1,
         minHeight: '44px',
@@ -211,6 +216,37 @@ export function ConnectionDetailOrderCard({
           </p>
         )}
       </div>
+
+      {/* Dispute strip */}
+      {hasOpenDispute && (
+        <div style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '6px',
+          marginTop: '8px',
+          padding: '7px 10px',
+          backgroundColor: 'rgba(139, 92, 246, 0.05)',
+          borderRadius: '8px',
+          border: '0.5px solid rgba(139, 92, 246, 0.12)',
+        }}>
+          <div style={{
+            width: '6px',
+            height: '6px',
+            borderRadius: '50%',
+            backgroundColor: '#8B5CF6',
+            flexShrink: 0,
+          }} />
+          <span style={{
+            fontSize: '11px',
+            fontWeight: 500,
+            color: '#6D28D9',
+            flex: 1,
+          }}>
+            Dispute open{disputeSummary ? ` · ${disputeSummary}` : ''}
+          </span>
+          <span style={{ fontSize: '12px', color: '#8B5CF6' }}>›</span>
+        </div>
+      )}
     </button>
   )
 }

--- a/src/components/order/OrderCard.tsx
+++ b/src/components/order/OrderCard.tsx
@@ -16,6 +16,8 @@ export interface OrderCardProps {
   isBuyer: boolean
   // true = money going OUT (red ↑), false = money coming IN (green ↓)
   onClick: () => void
+  hasOpenDispute?: boolean
+  disputeSummary?: string | null
 }
 
 // ─── Delivery pill colors (green ramp) ──────────────────────────────────────
@@ -154,6 +156,8 @@ export function OrderCard({
   latestActivity,
   isBuyer,
   onClick,
+  hasOpenDispute = false,
+  disputeSummary,
 }: OrderCardProps) {
   // ── Amount display ──────────────────────────────────────────────────────────
   const isPaid = settlementState === 'Paid'
@@ -181,7 +185,8 @@ export function OrderCard({
       style={{
         backgroundColor: 'var(--bg-card)',
         border: '1px solid var(--border-light)',
-        borderRadius: 'var(--radius-card)',
+        borderLeft: hasOpenDispute ? '3px solid #8B5CF6' : '1px solid var(--border-light)',
+        borderRadius: hasOpenDispute ? '0 var(--radius-card) var(--radius-card) 0' : 'var(--radius-card)',
         padding: '10px 14px',
         display: 'block',
       }}
@@ -263,6 +268,37 @@ export function OrderCard({
             </span>{' '}
             {dueInfo.suffix.split(' ').slice(1).join(' ')}
           </span>
+        </div>
+      )}
+
+      {/* Dispute strip */}
+      {hasOpenDispute && (
+        <div style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '6px',
+          marginTop: '8px',
+          padding: '7px 10px',
+          backgroundColor: 'rgba(139, 92, 246, 0.05)',
+          borderRadius: '8px',
+          border: '0.5px solid rgba(139, 92, 246, 0.12)',
+        }}>
+          <div style={{
+            width: '6px',
+            height: '6px',
+            borderRadius: '50%',
+            backgroundColor: '#8B5CF6',
+            flexShrink: 0,
+          }} />
+          <span style={{
+            fontSize: '11px',
+            fontWeight: 500,
+            color: '#6D28D9',
+            flex: 1,
+          }}>
+            Dispute open{disputeSummary ? ` · ${disputeSummary}` : ''}
+          </span>
+          <span style={{ fontSize: '12px', color: '#8B5CF6' }}>›</span>
         </div>
       )}
     </button>

--- a/src/hooks/data/use-business-data.ts
+++ b/src/hooks/data/use-business-data.ts
@@ -20,6 +20,7 @@ export interface EnrichedOrder extends OrderWithPaymentState {
   contactName?: string | null
   isBuyer: boolean
   hasOpenIssue: boolean
+  openIssueSummary?: string | null
 }
 
 interface AttentionCounts {
@@ -114,6 +115,14 @@ export function useOrdersData(currentBusinessId: string, isActive = true) {
           .filter(issue => issue.status === 'Open' || issue.status === 'Acknowledged')
           .map(issue => issue.orderId)
       )
+      const openIssueSummaryMap = new Map<string, string>()
+      allIssues
+        .filter(issue => issue.status === 'Open' || issue.status === 'Acknowledged')
+        .forEach(issue => {
+          if (!openIssueSummaryMap.has(issue.orderId)) {
+            openIssueSummaryMap.set(issue.orderId, issue.issueType)
+          }
+        })
 
       return allOrders
         .map(order => {
@@ -132,6 +141,7 @@ export function useOrdersData(currentBusinessId: string, isActive = true) {
             contactName: conn?.contactName,
             isBuyer: conn?.buyerBusinessId === currentBusinessId,
             hasOpenIssue: openIssueOrderIds.has(order.id),
+            openIssueSummary: openIssueSummaryMap.get(order.id) ?? null,
           }
         })
         .sort((a, b) => b.latestActivity - a.latestActivity)
@@ -159,9 +169,28 @@ export function useBusinessOverviewData(currentBusinessId: string, isActive = tr
       ).length
 
       const orderIds = orders.map(order => order.id)
-      const paymentEvents = orderIds.length > 0
-        ? await dataStore.getPaymentEventsByOrderIds(orderIds)
-        : []
+      const [paymentEvents, allIssues] = await Promise.all([
+        orderIds.length > 0
+          ? dataStore.getPaymentEventsByOrderIds(orderIds)
+          : Promise.resolve([]),
+        orderIds.length > 0
+          ? dataStore.getIssueReportsByOrderIds(orderIds)
+          : Promise.resolve([]),
+      ])
+
+      const overviewOpenIssueOrderIds = new Set(
+        allIssues
+          .filter(issue => issue.status === 'Open' || issue.status === 'Acknowledged')
+          .map(issue => issue.orderId)
+      )
+      const overviewOpenIssueSummaryMap = new Map<string, string>()
+      allIssues
+        .filter(issue => issue.status === 'Open' || issue.status === 'Acknowledged')
+        .forEach(issue => {
+          if (!overviewOpenIssueSummaryMap.has(issue.orderId)) {
+            overviewOpenIssueSummaryMap.set(issue.orderId, issue.issueType)
+          }
+        })
 
       const userAccount = session?.email
         ? await dataStore.getUserAccountByEmail(session.email)
@@ -332,6 +361,8 @@ export function useBusinessOverviewData(currentBusinessId: string, isActive = tr
             isBuyer: connection?.buyerBusinessId === currentBusinessId,
             branchLabel: connection?.branchLabel,
             contactName: connection?.contactName,
+            hasOpenIssue: overviewOpenIssueOrderIds.has(order.id),
+            openIssueSummary: overviewOpenIssueSummaryMap.get(order.id) ?? null,
           }
         })
         .sort((a, b) => b.latestActivity - a.latestActivity)


### PR DESCRIPTION
## Summary
This PR adds visual indicators for orders with open disputes across the application. Orders with open disputes now display a purple left border and an expandable dispute summary strip showing the issue type.

## Key Changes
- **Order Card Components**: Added `hasOpenDispute` and `disputeSummary` props to `OrderCard` and `ConnectionDetailOrderCard` components
  - Modified border styling: left border changes to 3px purple when dispute is open
  - Border radius adjusted to accommodate the left border indicator
  - Added dispute strip UI with purple accent color, dot indicator, and issue type summary

- **Data Layer**: Enhanced `useOrdersData` and `useBusinessOverviewData` hooks to track open dispute information
  - Created `openIssueSummaryMap` to store the issue type for each order with an open dispute
  - Added `openIssueSummary` field to `EnrichedOrder` interface
  - Optimized `useBusinessOverviewData` to fetch issues in parallel with payment events

- **Screen Components**: Updated all order display screens to pass dispute data to card components
  - `ConnectionDetailScreen`: Passes `hasOpenDispute` and `disputeSummary` to `ConnectionDetailOrderCard`
  - `OrdersScreen`: Passes dispute data from enriched order data to `OrderCard`
  - `DashboardScreen`: Passes dispute data to `OrderCard` in overview section

## Implementation Details
- Dispute indicator uses purple color scheme (#8B5CF6, #6D28D9) for visual consistency
- Dispute strip displays "Dispute open" with optional issue type summary (e.g., "Dispute open · Payment Dispute")
- Only the first open/acknowledged issue per order is displayed in the summary
- Styling is inline to maintain consistency with existing card component patterns

https://claude.ai/code/session_01GvLK6XEcSKGSRoSxzqEDs8