### PR TITLE
Add dispute status filter to order search and filtering

### DIFF
--- a/src/components/ConnectionDetailScreen.tsx
+++ b/src/components/ConnectionDetailScreen.tsx
@@ -211,6 +211,7 @@ export function ConnectionDetailScreen({ connectionId, currentBusinessId, onBack
             && order.calculatedDueDate < now
             && order.settlementState !== 'Paid'
         }
+        if (chip === 'dispute')    return openIssueOrderIds.has(order.id)
         return false
       })
       if (!matchChip) return false

--- a/src/components/OrdersScreen.tsx
+++ b/src/components/OrdersScreen.tsx
@@ -47,7 +47,7 @@ const EMPTY_FILTERS: OrderFilters = {
 }
 
 function matchesChip(
-  order: { lifecycleState: string; settlementState: string; calculatedDueDate: number | null },
+  order: { lifecycleState: string; settlementState: string; calculatedDueDate: number | null; hasOpenIssue?: boolean },
   chip: StatusChip,
   role: RoleFilter
 ): boolean {
@@ -75,6 +75,8 @@ function matchesChip(
       return order.settlementState === 'Paid'
     case 'overdue':
       return isOverdue
+    case 'dispute':
+      return order.hasOpenIssue === true
   }
 }
 

--- a/src/components/order/FilterSheet.tsx
+++ b/src/components/order/FilterSheet.tsx
@@ -124,6 +124,8 @@ function getStatusChipBackground(status: StatusChip): string {
       return 'rgba(34, 181, 115, 0.1)'
     case 'overdue':
       return 'rgba(255, 107, 107, 0.1)'
+    case 'dispute':
+      return 'rgba(139, 92, 246, 0.08)'
     default:
       return 'var(--bg-screen)'
   }
@@ -143,6 +145,8 @@ function getStatusChipColor(status: StatusChip): string {
       return 'var(--status-success, #22B573)'
     case 'overdue':
       return 'var(--status-overdue, #FF6B6B)'
+    case 'dispute':
+      return '#8B5CF6'
     default:
       return 'var(--text-secondary)'
   }

--- a/src/components/order/OrderSearchPanel.tsx
+++ b/src/components/order/OrderSearchPanel.tsx
@@ -12,6 +12,7 @@ export type StatusChip =
   | 'delivered'
   | 'paid'
   | 'overdue'
+  | 'dispute'
 
 export interface OrderFilters {
   searchText: string
@@ -21,9 +22,9 @@ export interface OrderFilters {
 }
 
 export const CHIPS_BY_ROLE: Record<RoleFilter, StatusChip[]> = {
-  all:     ['placed', 'dispatched', 'delivered', 'paid', 'overdue'],
-  buying:  ['placed', 'dispatched', 'delivered', 'paid', 'overdue'],
-  selling: ['new', 'accepted', 'dispatched', 'delivered', 'paid', 'overdue'],
+  all:     ['placed', 'dispatched', 'delivered', 'paid', 'overdue', 'dispute'],
+  buying:  ['placed', 'dispatched', 'delivered', 'paid', 'overdue', 'dispute'],
+  selling: ['new', 'accepted', 'dispatched', 'delivered', 'paid', 'overdue', 'dispute'],
 }
 
 export const CHIP_LABELS: Record<StatusChip, string> = {
@@ -34,6 +35,7 @@ export const CHIP_LABELS: Record<StatusChip, string> = {
   delivered:  'Delivered',
   paid:       'Paid',
   overdue:    'Overdue',
+  dispute:    'Dispute',
 }
 
 export const CHIP_COLORS: Record<StatusChip, string> = {
@@ -44,6 +46,7 @@ export const CHIP_COLORS: Record<StatusChip, string> = {
   delivered:  'var(--status-delivered, #22B573)',
   paid:       'var(--status-success, #22B573)',
   overdue:    'var(--status-overdue, #FF6B6B)',
+  dispute:    'var(--status-dispute, #8B5CF6)',
 }
 
 const MONTH_NAMES = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']


### PR DESCRIPTION
## Summary
This PR adds support for a new "dispute" status filter to the order management system, allowing users to filter and view orders that have open issues/disputes.

## Key Changes
- **OrderSearchPanel.tsx**: Added 'dispute' as a new `StatusChip` type and included it in the status filter options for all user roles (all, buying, selling)
- **OrdersScreen.tsx**: Extended the `matchesChip` function to handle the 'dispute' status by checking the `hasOpenIssue` property on orders, and updated the order type signature to include the optional `hasOpenIssue` field
- **FilterSheet.tsx**: Added styling for the dispute status chip with a purple color scheme (`#8B5CF6`) and corresponding background color (`rgba(139, 92, 246, 0.08)`)
- **ConnectionDetailScreen.tsx**: Implemented dispute filtering logic to match orders with open issues against the `openIssueOrderIds` set

## Implementation Details
- The dispute status uses a purple color (`#8B5CF6`) to visually distinguish it from other statuses
- The filter checks for `hasOpenIssue === true` on order objects to determine if an order should be tagged as disputed
- The dispute filter is available across all user roles (all, buying, and selling)
- Consistent styling applied across both the main filter panel and the connection detail screen

https://claude.ai/code/session_01EY7jTjoxqDv5mSCvxZgbR7