### PR TITLE
Simplify share functionality to copy Zelto ID only

### DIFF
--- a/src/components/ProfileScreen.tsx
+++ b/src/components/ProfileScreen.tsx
@@ -212,7 +212,7 @@ export function ProfileScreen({
   }
 
   const handleShare = async () => {
-    const shareMessage = `Connect with ${business.businessName} on Zelto — ID: ${business.zeltoId}`
+    const shareMessage = business.zeltoId
 
     if (navigator.share) {
       try {
@@ -224,7 +224,7 @@ export function ProfileScreen({
       }
     } else {
       await navigator.clipboard.writeText(shareMessage)
-      toast.success('Link copied to clipboard')
+      toast.success('Zelto ID copied')
     }
   }
 


### PR DESCRIPTION
## Summary
Updated the share functionality in ProfileScreen to simplify the sharing experience by copying only the Zelto ID instead of a formatted message with business name and ID.

## Key Changes
- Changed `shareMessage` from a formatted string (`"Connect with ${business.businessName} on Zelto — ID: ${business.zeltoId}"`) to just the `business.zeltoId`
- Updated the success toast message from `'Link copied to clipboard'` to `'Zelto ID copied'` to accurately reflect what is being shared

## Implementation Details
This change streamlines the share flow by reducing the shared content to just the essential identifier (Zelto ID), making it more concise and easier for users to share and reference.

https://claude.ai/code/session_01JSKBN9SNWzMNbst4Rt6a3c