### PR TITLE
Reorder navigation tabs: move Orders after Connections

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1027,17 +1027,17 @@ function TabShell({
             onClick={() => onNavigateToTab('dashboard')}
           />
           <TabButton
-            label="Orders"
-            icon={<Package weight="regular" size={22} />}
-            active={activeTabScreen.tab === 'orders'}
-            onClick={() => onNavigateToTab('orders')}
-          />
-          <TabButton
             label="Connections"
             icon={<Users weight="regular" size={22} />}
             active={activeTabScreen.tab === 'connections'}
             onClick={() => onNavigateToTab('connections')}
             hasUnread={hasUnreadConnections}
+          />
+          <TabButton
+            label="Orders"
+            icon={<Package weight="regular" size={22} />}
+            active={activeTabScreen.tab === 'orders'}
+            onClick={() => onNavigateToTab('orders')}
           />
           <TabButton
             label="Business"


### PR DESCRIPTION
## Summary
Reordered the navigation tabs in the TabShell component to change the tab sequence in the UI.

## Changes
- Moved the "Orders" tab button to appear after the "Connections" tab instead of before it
- The tab functionality and behavior remain unchanged; this is purely a UI/UX ordering adjustment

## Details
The navigation tab order is now:
1. Dashboard
2. Connections
3. Orders
4. Business

This change affects the visual layout of the main navigation without modifying any underlying logic or functionality.

https://claude.ai/code/session_012zJzmDEhmGYszPfYgs9z6h