### PR TITLE
Remove uncertain inflow category from cash forecast

### DIFF
--- a/src/components/DashboardScreen.tsx
+++ b/src/components/DashboardScreen.tsx
@@ -472,11 +472,7 @@ export function DashboardScreen({ currentBusinessId, onNavigateToOrders, onNavig
             onTapCollectionItem={(connId) => onNavigateToConnection(connId)}
             onTapForecastRow={(type, label) => {
               if (type === 'inflow') {
-                if (label === 'Uncertain') {
-                  onNavigateToOrders(undefined, { role: 'selling', chip: 'dispatched' })
-                } else {
-                  onNavigateToOrders(undefined, { role: 'selling', chip: 'delivered' })
-                }
+                onNavigateToOrders(undefined, { role: 'selling', chip: 'delivered' })
               } else {
                 if (label === 'This Week') {
                   onNavigateToOrders(undefined, { role: 'buying', chip: 'overdue' })

--- a/src/components/dashboard/CashForecastCard.tsx
+++ b/src/components/dashboard/CashForecastCard.tsx
@@ -38,7 +38,7 @@ export function CashForecastCard({ forecast, loading }: Props) {
       label: `Inflow — ${bucket.label}`,
       sublabel: bucket.detail,
       amount: bucket.amount,
-      colorType: bucket.label === 'Uncertain' ? 'amber' : 'green',
+      colorType: 'green',
     })),
     ...forecast.outflows.map((bucket) => ({
       label: `Outflow — ${bucket.label}`,

--- a/src/components/dashboard/MoneyCard.tsx
+++ b/src/components/dashboard/MoneyCard.tsx
@@ -217,7 +217,7 @@ export function MoneyCard({ forecast, collectionItems, concentrationRisk, loadin
                     <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
                       <p style={{
                         fontSize: '14px', fontWeight: 600, margin: 0,
-                        color: bucket.label === 'Uncertain' ? '#D97706' : '#22B573',
+                        color: '#22B573',
                       }}>
                         {formatInrCurrency(bucket.amount)}
                       </p>

--- a/src/lib/intelligence-engine.ts
+++ b/src/lib/intelligence-engine.ts
@@ -262,7 +262,7 @@ export class IntelligenceEngine {
     // Inflow accumulators
     const inflowThisWeek = { amount: 0, count: 0 }
     const inflowNextWeek = { amount: 0, count: 0 }
-    const inflowUncertain = { amount: 0, count: 0 }
+
 
     // INFLOWS (business is supplier)
     for (const connection of supplierConnections) {
@@ -342,8 +342,8 @@ export class IntelligenceEngine {
         const daysFromNow = (expectedPayDate - now) / 86400000
 
         if (!hasEnoughHistory || daysFromNow > 14) {
-          inflowUncertain.amount += order.pendingAmount
-          inflowUncertain.count++
+          // Skip — not enough data to predict, or too far out
+          continue
         } else if (daysFromNow <= 7) {
           inflowThisWeek.amount += order.pendingAmount
           inflowThisWeek.count++
@@ -404,14 +404,7 @@ export class IntelligenceEngine {
         detail: `${inflowNextWeek.count} order${inflowNextWeek.count > 1 ? 's' : ''} expected next week`,
       })
     }
-    if (inflowUncertain.count > 0) {
-      inflows.push({
-        label: 'Uncertain',
-        amount: inflowUncertain.amount,
-        orderCount: inflowUncertain.count,
-        detail: `${inflowUncertain.count} order${inflowUncertain.count > 1 ? 's' : ''} with uncertain timing`,
-      })
-    }
+
 
     // Build outflow buckets
     const outflows: CashForecastBucket[] = []


### PR DESCRIPTION
## Summary
This PR removes the "Uncertain" inflow category from the cash forecast feature. Orders that lack sufficient historical data or have expected payment dates beyond 14 days are now skipped entirely rather than being accumulated in an uncertain bucket.

## Key Changes
- **Intelligence Engine**: Removed `inflowUncertain` accumulator and replaced logic that tracked uncertain orders with a `continue` statement to skip them
- **Dashboard Screen**: Simplified inflow navigation to always filter by 'delivered' status, removing the special case for 'Uncertain' label
- **Cash Forecast Card**: Removed conditional color logic for uncertain inflows; all inflows now display in green
- **Money Card**: Removed amber color styling for uncertain inflows; all inflows now display in green (#22B573)

## Implementation Details
The change simplifies the cash forecast by removing a category that represented low-confidence predictions. Orders without sufficient historical data or with payment dates too far in the future are now excluded from the forecast entirely, rather than being presented as a separate uncertain category. This reduces UI complexity and focuses the forecast on more reliable predictions.

https://claude.ai/code/session_019c8wZK7jfJvyDJrMbYuGbc