### PR TITLE
Simplify connections sorting and orders header display

### DIFF
--- a/src/components/ConnectionsScreen.tsx
+++ b/src/components/ConnectionsScreen.tsx
@@ -139,14 +139,7 @@ export function ConnectionsScreen({ currentBusinessId, onSelectConnection, onAdd
 
     console.debug('[ConnectionsScreen] fetch end', Date.now(), { currentBusinessId })
 
-    connectionsWithState.sort((a, b) => {
-      if (a.outstandingBalance !== b.outstandingBalance) return b.outstandingBalance - a.outstandingBalance
-      const riskOrder: Record<ConnectionState, number> = { 'Under Stress': 3, 'Friction Rising': 2, 'Active': 1, 'Stable': 0 }
-      const riskA = riskOrder[a.computedState] ?? 0
-      const riskB = riskOrder[b.computedState] ?? 0
-      if (riskA !== riskB) return riskB - riskA
-      return b.createdAt - a.createdAt
-    })
+    connectionsWithState.sort((a, b) => b.createdAt - a.createdAt)
 
     if (!cachedConns || !isSameConnections(cachedConns, connectionsWithState)) {
       if (!cachedConnectionsByBusiness.has(currentBusinessId) && cachedConnectionsByBusiness.size >= MAX_CACHED_BUSINESSES) {

--- a/src/components/OrdersScreen.tsx
+++ b/src/components/OrdersScreen.tsx
@@ -707,7 +707,7 @@ export function OrdersScreen({ currentBusinessId, onSelectOrder, initialFilter, 
               const hasSearch = orderFilters.searchText.trim().length > 0
               const hasChips = hasActiveFilters
               if (!hasSearch && !hasChips) {
-                return `${totalOrders} orders`
+                return null
               }
               if (hasSearch && hasChips) {
                 const chipLabels = activeStatusFilters.map(c => CHIP_LABELS[c]).join(' + ')


### PR DESCRIPTION
## Summary
This PR simplifies the sorting logic in ConnectionsScreen and updates the OrdersScreen header display behavior.

## Key Changes
- **ConnectionsScreen**: Replaced complex multi-criteria sorting (by outstanding balance, risk state, and creation date) with simple chronological sorting by `createdAt` in descending order
- **OrdersScreen**: Changed the orders header to return `null` instead of displaying "{totalOrders} orders" when no search text or active filters are present

## Implementation Details
The ConnectionsScreen change removes the risk-based prioritization that previously surfaced connections with higher outstanding balances and riskier states. The new implementation sorts connections purely by creation date, showing the most recently created connections first.

The OrdersScreen change affects the header display logic - when viewing all orders without any filters or search, the header will now be empty rather than showing the total count.

https://claude.ai/code/session_01VtZcskYtSasZW77BMBDFkk