### PR TITLE
Fix pill styling and remove dashboard subtitle

### DIFF
--- a/src/components/DashboardScreen.tsx
+++ b/src/components/DashboardScreen.tsx
@@ -113,7 +113,7 @@ export function DashboardScreen({ currentBusinessId, onNavigateToOrders, onNavig
         <div className="px-4 flex items-start justify-between" style={{ paddingTop: '20px', paddingBottom: '16px' }}>
           <div>
             <h1 className="text-[20px] font-semibold" style={{ color: '#111' }}>{data.username ? `Welcome back, ${data.username}` : 'Welcome back'}</h1>
-            <p className="text-[13px] font-normal mt-1" style={{ color: '#8A8A8A' }}>Your trade snapshot today</p>
+
           </div>
           {overview.credibility && overview.credibility.level !== 'none' && (
             <div className="flex items-center gap-1">

--- a/src/components/order/ConnectionDetailOrderCard.tsx
+++ b/src/components/order/ConnectionDetailOrderCard.tsx
@@ -32,6 +32,8 @@ const HALF_PILL_BASE: CSSProperties = {
   color: '#FFFFFF',
   display: 'inline-block',
   whiteSpace: 'nowrap',
+  minWidth: '80px',
+  textAlign: 'center',
 }
 
 function getDeliveryPillStyle(lifecycleState: string): CSSProperties {

--- a/src/components/order/OrderCard.tsx
+++ b/src/components/order/OrderCard.tsx
@@ -84,6 +84,8 @@ const HALF_PILL_BASE: CSSProperties = {
   color: '#FFFFFF',
   display: 'inline-block',
   whiteSpace: 'nowrap',
+  minWidth: '80px',
+  textAlign: 'center',
 }
 
 // ─── Due date text helpers ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
This PR makes minor UI adjustments to improve consistency and clarity across the dashboard and order components.

## Key Changes
- **DashboardScreen**: Removed the "Your trade snapshot today" subtitle text below the welcome message
- **Order Cards**: Added consistent styling to delivery status pills in both `OrderCard` and `ConnectionDetailOrderCard` components:
  - Set `minWidth: '80px'` to ensure pills have a minimum width
  - Added `textAlign: 'center'` to center-align the text within pills

## Implementation Details
The pill styling changes ensure that delivery status badges maintain a consistent, readable appearance with proper spacing and alignment across different order card variants.

https://claude.ai/code/session_015cw4dEEk1qpSbwtiuK3bsd