### PR TITLE
claude/fix-ios-pwa-notifications-iHwG2

### DIFF
--- a/src/lib/push-notifications.ts
+++ b/src/lib/push-notifications.ts
@@ -167,19 +167,24 @@ async function persistWebPushSubscription(
     return
   }
 
-  const { error } = await supabase.from('device_tokens').upsert(
-    {
-      user_id: account.userId,
-      business_entity_id: account.businessEntityId,
-      platform: 'web',
-      push_endpoint: endpoint,
-      push_p256dh: p256dh,
-      push_auth: auth,
-      updated_at: Date.now(),
-      created_at: Date.now(),
-    },
-    { onConflict: 'user_id,push_endpoint' },
-  )
+  // PostgREST can't match the partial unique index for upsert, so we
+  // delete-then-insert instead. Both operations have RLS policies.
+  await supabase
+    .from('device_tokens')
+    .delete()
+    .eq('user_id', account.userId)
+    .eq('platform', 'web')
+
+  const { error } = await supabase.from('device_tokens').insert({
+    user_id: account.userId,
+    business_entity_id: account.businessEntityId,
+    platform: 'web',
+    push_endpoint: endpoint,
+    push_p256dh: p256dh,
+    push_auth: auth,
+    updated_at: Date.now(),
+    created_at: Date.now(),
+  })
 
   if (error) {
     console.error('Failed to save web push subscription:', error)
@@ -205,9 +210,10 @@ async function registerWebPush(businessEntityId: string): Promise<void> {
     return
   }
 
-  // Register the push-specific service worker
-  const registration = await navigator.serviceWorker.register('/sw-push.js', { scope: '/' })
-  await navigator.serviceWorker.ready
+  // Use the Workbox service worker that's already registered by vite-plugin-pwa.
+  // sw-push.js is imported into it via workbox.importScripts — do NOT register
+  // a separate SW here or it will conflict with the Workbox one.
+  const registration = await navigator.serviceWorker.ready
 
   // Check for existing subscription first
   let subscription = await registration.pushManager.getSubscription()
@@ -249,8 +255,8 @@ export async function removeDeviceTokens(): Promise<void> {
   // Unsubscribe the web push subscription if on web
   if (!Capacitor.isNativePlatform() && 'serviceWorker' in navigator) {
     try {
-      const registration = await navigator.serviceWorker.getRegistration('/sw-push.js')
-      const subscription = await registration?.pushManager.getSubscription()
+      const registration = await navigator.serviceWorker.ready
+      const subscription = await registration.pushManager.getSubscription()
       if (subscription) await subscription.unsubscribe()
     } catch (e) {
       console.error('Failed to unsubscribe web push:', e)

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,6 +21,10 @@ export default defineConfig({
       base: '/',
       manifest: false, // disable — we use public/manifest.webmanifest directly
       workbox: {
+        // Import push notification handlers into the generated Workbox SW.
+        // This avoids registering a second SW at the same scope (which would
+        // cause the Workbox SW and push SW to fight each other on iOS).
+        importScripts: ['/sw-push.js'],
         maximumFileSizeToCacheInBytes: 3 * 1024 * 1024,
         globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}'],
         navigateFallback: 'index.html',


### PR DESCRIPTION
Two issues prevented web push from working:

1. Service worker scope conflict: vite-plugin-pwa registers sw.js at
   scope '/' and our code registered sw-push.js at the same scope.
   The Workbox SW would replace the push SW on every page load, killing
   push subscriptions. Fix: use workbox.importScripts to merge push
   handlers into the generated Workbox SW instead of registering a
   separate service worker.

2. Upsert with partial unique index: PostgREST cannot match partial
   unique indexes for ON CONFLICT resolution, so the upsert silently
   failed and the subscription was never saved. Fix: use delete + insert
   instead of upsert.

https://claude.ai/code/session_01R2EXrRGPStzJTyqCxjHjZs