### PR TITLE
claude/add-push-debug-notification-5sWNv

### DIFF
--- a/public/sw-push.js
+++ b/public/sw-push.js
@@ -2,6 +2,7 @@
 // This file must be served from the root scope (/) for push to work.
 
 self.addEventListener('push', (event) => {
+  self.registration.showNotification('[DEBUG] push fired', { body: 'has data: ' + !!event.data });
   let data = { title: 'Zelto', body: '' }
 
   if (event.data) {
@@ -21,6 +22,7 @@ self.addEventListener('push', (event) => {
     data: data.data || {},
   }
 
+  self.registration.showNotification('[DEBUG] about to call showNotification', { body: JSON.stringify(data).slice(0, 100) });
   event.waitUntil(
     self.registration.showNotification(data.title || 'Zelto', options).then(() => {
       // Notify open client windows so they can refresh in-app state


### PR DESCRIPTION
Adds two debug showNotification calls to diagnose push notification
issues — one at the top of the push handler and one right before the
main showNotification call. To be removed after diagnosis.

https://claude.ai/code/session_01T3Nv4evt79wmY73QR9EPGF