### PR TITLE
claude/fix-notification-cascade-BGbF2

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -191,7 +191,7 @@ function App() {
   useEffect(() => {
     if (!currentBusinessId) return
     void checkUnread()
-  }, [currentBusinessId, navigationStack])
+  }, [currentBusinessId])
 
   // Periodic behaviour engine recalculation (every 20 minutes)
   useEffect(() => {
@@ -226,7 +226,7 @@ function App() {
   }, [currentBusinessId])
 
   useDataListener(
-    ['orders:changed', 'payments:changed', 'connections:changed', 'connection-requests:changed', 'notifications:changed'],
+    ['orders:changed', 'payments:changed', 'connections:changed', 'connection-requests:changed'],
     () => { checkUnreadRef.current() }
   )
 

--- a/src/lib/interactions.ts
+++ b/src/lib/interactions.ts
@@ -122,7 +122,7 @@ export async function createOrder(
 
   await recalculateConnectionState(connectionId)
 
-  emitDataChange('orders:changed', 'notifications:changed')
+  emitDataChange('orders:changed')
   return newOrder
 }
 
@@ -235,7 +235,7 @@ export async function transitionOrderState(
 
   await recalculateConnectionState(order.connectionId)
 
-  emitDataChange('orders:changed', 'notifications:changed')
+  emitDataChange('orders:changed')
   return updatedOrder
 }
 
@@ -306,7 +306,7 @@ export async function recordPayment(
 
   await recalculateConnectionState(order.connectionId)
 
-  emitDataChange('payments:changed', 'orders:changed', 'notifications:changed')
+  emitDataChange('payments:changed', 'orders:changed')
   return newPayment
 }
 
@@ -360,7 +360,7 @@ export async function disputePayment(
 
   await recalculateConnectionState(order.connectionId)
 
-  emitDataChange('payments:changed', 'notifications:changed')
+  emitDataChange('payments:changed')
   return updatedPayment
 }
 
@@ -418,7 +418,7 @@ export async function createIssue(
 
   await recalculateConnectionState(order.connectionId)
 
-  emitDataChange('issues:changed', 'notifications:changed')
+  emitDataChange('issues:changed')
   return newIssue
 }
 
@@ -483,7 +483,7 @@ export async function acknowledgeIssue(
 
   await recalculateConnectionState(order.connectionId)
 
-  emitDataChange('issues:changed', 'notifications:changed')
+  emitDataChange('issues:changed')
   return updatedIssue
 }
 
@@ -555,7 +555,7 @@ export async function resolveIssue(
 
   await recalculateConnectionState(order.connectionId)
 
-  emitDataChange('issues:changed', 'payments:changed', 'notifications:changed')
+  emitDataChange('issues:changed', 'payments:changed')
   return updatedIssue
 }
 
@@ -610,7 +610,7 @@ export async function closeIssue(
 
   await recalculateConnectionState(order.connectionId)
 
-  emitDataChange('issues:changed', 'notifications:changed')
+  emitDataChange('issues:changed')
   return updatedIssue
 }
 
@@ -674,7 +674,7 @@ export async function addIssueComment(
 
   await recalculateConnectionState(order.connectionId)
 
-  emitDataChange('issues:changed', 'notifications:changed')
+  emitDataChange('issues:changed')
   return comment
 }
 


### PR DESCRIPTION
Every mutation in interactions.ts emitted notifications:changed alongside
its domain event, and App.tsx listened to notifications:changed to run
checkUnread (which calls the expensive attentionEngine.getAttentionItems).
Combined with data hooks refreshing on both events, every action triggered
two cascading heavy fetches; on first login this stalled the UI.

- Drop notifications:changed from App.tsx's checkUnread listener.
- Stop re-running checkUnread on every navigationStack change; the data
  listener already handles data-changed refreshes.
- Strip notifications:changed from every emitDataChange in interactions.ts.
  The notification row is still written; useProfileData (bell badge) and
  NotificationHistoryScreen still listen to notifications:changed and will
  refresh when notifications are actually read.