### PR TITLE
claude/fix-notification-format-no4Xj

### DIFF
--- a/sql/create_accept_connection_request_rpc.sql
+++ b/sql/create_accept_connection_request_rpc.sql
@@ -109,24 +109,32 @@ BEGIN
     WHERE id = p_request_id;
 
     BEGIN
-      INSERT INTO notifications (
-        recipient_business_id,
-        type,
-        related_entity_id,
-        connection_id,
-        message,
-        created_at,
-        read_at
-      ) VALUES (
-        v_request.requester_business_id,
-        'ConnectionAccepted',
-        v_connection_id,
-        v_connection_id,
-        'Your connection request has been accepted',
-        v_now,
-        NULL
-      );
-      v_notification_status := 'sent';
+      DECLARE
+        v_accepter_name TEXT;
+      BEGIN
+        SELECT business_name INTO v_accepter_name
+        FROM business_entities
+        WHERE id = p_actor_business_id;
+
+        INSERT INTO notifications (
+          recipient_business_id,
+          type,
+          related_entity_id,
+          connection_id,
+          message,
+          created_at,
+          read_at
+        ) VALUES (
+          v_request.requester_business_id,
+          'ConnectionAccepted',
+          v_connection_id,
+          v_connection_id,
+          'Connection accepted|' || COALESCE(v_accepter_name, 'A business') || ' accepted your connection request',
+          v_now,
+          NULL
+        );
+        v_notification_status := 'sent';
+      END;
     EXCEPTION WHEN OTHERS THEN
       v_notification_status := 'failed';
     END;

--- a/src/components/NotificationHistoryScreen.tsx
+++ b/src/components/NotificationHistoryScreen.tsx
@@ -6,6 +6,17 @@ import type { Notification, NotificationType } from '@/lib/types'
 import { CaretLeft } from '@phosphor-icons/react'
 import { useDataListener } from '@/lib/data-events'
 
+function splitNotificationMessage(message: string): { title: string; body: string } {
+  const pipeIndex = message.indexOf('|')
+  if (pipeIndex < 0) {
+    return { title: '', body: message }
+  }
+  return {
+    title: message.slice(0, pipeIndex),
+    body: message.slice(pipeIndex + 1),
+  }
+}
+
 interface Props {
   currentBusinessId: string
   onBack: () => void
@@ -128,9 +139,21 @@ export function NotificationHistoryScreen({ currentBusinessId, onBack, onNavigat
                   }`}
                   style={isUnread ? { borderLeft: '3px solid #E8A020' } : {}} // Warning color for unread items
                 >
-                  <p className={`text-[14px] leading-snug mb-1 ${isUnread ? 'font-medium text-foreground' : 'text-foreground'}`}>
-                    {notification.message}
-                  </p>
+                  {(() => {
+                    const { title, body } = splitNotificationMessage(notification.message)
+                    return (
+                      <>
+                        {title && (
+                          <p className={`text-[14px] leading-snug ${isUnread ? 'font-semibold text-foreground' : 'font-semibold text-foreground'}`}>
+                            {title}
+                          </p>
+                        )}
+                        <p className={`text-[13px] leading-snug mb-1 ${title ? 'text-muted-foreground' : (isUnread ? 'font-medium text-foreground' : 'text-foreground')}`}>
+                          {body}
+                        </p>
+                      </>
+                    )
+                  })()}
                   <p className="text-[12px] text-muted-foreground">
                     {formatDistanceToNow(notification.createdAt, { addSuffix: true })}
                   </p>

--- a/src/lib/interactions.ts
+++ b/src/lib/interactions.ts
@@ -16,6 +16,27 @@ import type {
   RaisedBy,
 } from './types'
 
+/**
+ * Encode a notification title + body into the single `message` column.
+ * Consumers split on the first '|' character.
+ */
+function formatNotificationMessage(title: string, body: string): string {
+  return `${title}|${body}`
+}
+
+/**
+ * Resolve the "other party" business name for notifications.
+ * Returns a fallback string if the lookup fails so notifications never break.
+ */
+async function getOtherPartyName(otherPartyBusinessId: string): Promise<string> {
+  try {
+    const business = await dataStore.getBusinessEntityById(otherPartyBusinessId)
+    return business?.businessName ?? 'a connection'
+  } catch {
+    return 'a connection'
+  }
+}
+
 async function recalculateConnectionState(connectionId: string): Promise<void> {
   const newState = await behaviourEngine.computeConnectionState(connectionId)
   await dataStore.updateConnectionState(connectionId, newState)
@@ -109,12 +130,13 @@ export async function createOrder(
 
   // Notify supplier that a new order was placed
   try {
+    const buyerName = await getOtherPartyName(connection.buyerBusinessId)
     await dataStore.createNotification(
       connection.supplierBusinessId,
       'OrderPlaced',
       newOrder.id,
       connectionId,
-      `New order: ${itemSummary}`
+      formatNotificationMessage(itemSummary, `New order from ${buyerName}`)
     )
   } catch (err) {
     console.error('Notification failed:', err)
@@ -195,12 +217,13 @@ export async function transitionOrderState(
 
   if (newState === 'Accepted') {
     try {
+      const supplierName = await getOtherPartyName(connection.supplierBusinessId)
       await dataStore.createNotification(
         connection.buyerBusinessId,
         'OrderAccepted',
         orderId,
         order.connectionId,
-        `Your order has been accepted`
+        formatNotificationMessage(order.itemSummary, `Accepted by ${supplierName}`)
       )
     } catch (err) {
       console.error('Notification failed:', err)
@@ -208,12 +231,13 @@ export async function transitionOrderState(
   }
   if (newState === 'Dispatched') {
     try {
+      const supplierName = await getOtherPartyName(connection.supplierBusinessId)
       await dataStore.createNotification(
         connection.buyerBusinessId,
         'OrderDispatched',
         orderId,
         order.connectionId,
-        `Your order has been dispatched`
+        formatNotificationMessage(order.itemSummary, `Dispatched by ${supplierName}`)
       )
     } catch (err) {
       console.error('Notification failed:', err)
@@ -221,12 +245,13 @@ export async function transitionOrderState(
   }
   if (newState === 'Declined') {
     try {
+      const supplierName = await getOtherPartyName(connection.supplierBusinessId)
       await dataStore.createNotification(
         connection.buyerBusinessId,
         'OrderDeclined',
         orderId,
         order.connectionId,
-        `Your order has been declined`
+        formatNotificationMessage(order.itemSummary, `Declined by ${supplierName}`)
       )
     } catch (err) {
       console.error('Notification failed:', err)
@@ -293,12 +318,20 @@ export async function recordPayment(
     ? connection.supplierBusinessId
     : connection.buyerBusinessId
   try {
+    const otherPartyName = await getOtherPartyName(
+      requestingBusinessId === connection.buyerBusinessId
+        ? connection.buyerBusinessId
+        : connection.supplierBusinessId
+    )
     await dataStore.createNotification(
       otherPartyId,
       'PaymentRecorded',
       orderId,
       order.connectionId,
-      `Payment of ₹${amount.toLocaleString('en-IN')} recorded`
+      formatNotificationMessage(
+        `Payment of ₹${amount.toLocaleString('en-IN')}`,
+        `Recorded by ${otherPartyName} for ${order.itemSummary}`
+      )
     )
   } catch (err) {
     console.error('Notification failed:', err)
@@ -347,12 +380,16 @@ export async function disputePayment(
     ? connection.supplierBusinessId
     : connection.buyerBusinessId
   try {
+    const disputerName = await getOtherPartyName(requestingBusinessId)
     await dataStore.createNotification(
       otherPartyId,
       'PaymentDisputed',
       paymentEventId,
       order.connectionId,
-      `A payment has been disputed`
+      formatNotificationMessage(
+        `Payment disputed`,
+        `${disputerName} disputed a payment on ${order.itemSummary}`
+      )
     )
   } catch (err) {
     console.error('Notification failed:', err)
@@ -405,12 +442,16 @@ export async function createIssue(
     ? connection.supplierBusinessId
     : connection.buyerBusinessId
   try {
+    const raiserName = await getOtherPartyName(requestingBusinessId)
     await dataStore.createNotification(
       otherPartyId,
       'IssueRaised',
       newIssue.id,
       order.connectionId,
-      `New issue reported: ${issueType}`
+      formatNotificationMessage(
+        `Issue: ${issueType}`,
+        `Reported by ${raiserName} on ${order.itemSummary}`
+      )
     )
   } catch (err) {
     console.error('Notification failed:', err)
@@ -470,12 +511,16 @@ export async function acknowledgeIssue(
     ? connection.buyerBusinessId
     : connection.supplierBusinessId
   try {
+    const acknowledgerName = await getOtherPartyName(requestingBusinessId)
     await dataStore.createNotification(
       raiserBusinessId,
       'IssueAcknowledged',
       issueId,
       order.connectionId,
-      `Issue acknowledged: ${targetIssue.issueType}`
+      formatNotificationMessage(
+        `Issue acknowledged: ${targetIssue.issueType}`,
+        `${acknowledgerName} saw your report on ${order.itemSummary}`
+      )
     )
   } catch (err) {
     console.error('Notification failed:', err)
@@ -530,12 +575,16 @@ export async function resolveIssue(
     ? connection.supplierBusinessId
     : connection.buyerBusinessId
   try {
+    const resolverName = await getOtherPartyName(requestingBusinessId)
     await dataStore.createNotification(
       otherPartyId,
       'IssueResolved',
       issueId,
       order.connectionId,
-      `Issue resolved: ${targetIssue.issueType}`
+      formatNotificationMessage(
+        `Issue resolved: ${targetIssue.issueType}`,
+        `Resolved by ${resolverName} on ${order.itemSummary}`
+      )
     )
   } catch (err) {
     console.error('Notification failed:', err)
@@ -597,12 +646,16 @@ export async function closeIssue(
     ? connection.supplierBusinessId
     : connection.buyerBusinessId
   try {
+    const closerName = await getOtherPartyName(requestingBusinessId)
     await dataStore.createNotification(
       otherPartyId,
       'IssueResolved',
       issueId,
       order.connectionId,
-      `Issue closed: ${targetIssue.issueType}`
+      formatNotificationMessage(
+        `Issue closed: ${targetIssue.issueType}`,
+        `Closed by ${closerName} on ${order.itemSummary}`
+      )
     )
   } catch (err) {
     console.error('Notification failed:', err)
@@ -661,12 +714,16 @@ export async function addIssueComment(
     ? connection.supplierBusinessId
     : connection.buyerBusinessId
   try {
+    const commenterName = await getOtherPartyName(requestingBusinessId)
     await dataStore.createNotification(
       otherPartyId,
       'IssueAcknowledged',
       issueId,
       order.connectionId,
-      `New response on issue: ${targetIssue.issueType}`
+      formatNotificationMessage(
+        `Reply on issue: ${targetIssue.issueType}`,
+        `${commenterName} responded on ${order.itemSummary}`
+      )
     )
   } catch (err) {
     console.error('Notification failed:', err)

--- a/supabase/functions/send-push/index.ts
+++ b/supabase/functions/send-push/index.ts
@@ -333,9 +333,17 @@ serve(async (req) => {
     const { record } = await req.json()
 
     const recipientBusinessId = record.recipient_business_id
-    const message = record.message
+    const rawMessage = record.message as string
     const type = record.type
-    const title = NOTIFICATION_TITLES[type] || 'Zelto'
+
+    // Split encoded title|body. If no pipe, fall back to type-based title.
+    const pipeIndex = rawMessage.indexOf('|')
+    const title = pipeIndex >= 0
+      ? rawMessage.slice(0, pipeIndex)
+      : (NOTIFICATION_TITLES[type] || 'Zelto')
+    const message = pipeIndex >= 0
+      ? rawMessage.slice(pipeIndex + 1)
+      : rawMessage
 
     const pushData = {
       type,

--- a/supabase/migrations/20260313000001_create_accept_connection_request_rpc.sql
+++ b/supabase/migrations/20260313000001_create_accept_connection_request_rpc.sql
@@ -109,24 +109,32 @@ BEGIN
     WHERE id = p_request_id;
 
     BEGIN
-      INSERT INTO notifications (
-        recipient_business_id,
-        type,
-        related_entity_id,
-        connection_id,
-        message,
-        created_at,
-        read_at
-      ) VALUES (
-        v_request.requester_business_id,
-        'ConnectionAccepted',
-        v_connection_id,
-        v_connection_id,
-        'Your connection request has been accepted',
-        v_now,
-        NULL
-      );
-      v_notification_status := 'sent';
+      DECLARE
+        v_accepter_name TEXT;
+      BEGIN
+        SELECT business_name INTO v_accepter_name
+        FROM business_entities
+        WHERE id = p_actor_business_id;
+
+        INSERT INTO notifications (
+          recipient_business_id,
+          type,
+          related_entity_id,
+          connection_id,
+          message,
+          created_at,
+          read_at
+        ) VALUES (
+          v_request.requester_business_id,
+          'ConnectionAccepted',
+          v_connection_id,
+          v_connection_id,
+          'Connection accepted|' || COALESCE(v_accepter_name, 'A business') || ' accepted your connection request',
+          v_now,
+          NULL
+        );
+        v_notification_status := 'sent';
+      END;
     EXCEPTION WHEN OTHERS THEN
       v_notification_status := 'failed';
     END;


### PR DESCRIPTION
Every notification message is now stored as "<title>|<body>" in the
existing `message` column. The push edge function, the in-app list,
and the ConnectionAccepted RPC all understand the new format; legacy
rows without a pipe fall back to the type-based title.

- interactions.ts: formatNotificationMessage + getOtherPartyName
  helpers; every createNotification call site now emits title=item
  summary (or action subject) and body="<action> by/from <connection
  name>"
- accept_connection_request RPC: include the accepter's business name
  in the ConnectionAccepted message
- send-push/index.ts: split on first '|' to derive push title/body,
  fall back to NOTIFICATION_TITLES for legacy rows
- NotificationHistoryScreen: render title bold, body muted below

https://claude.ai/code/session_01Y1GvEt8T7kUsacXtiNDG3z