### PR TITLE
Replace push notification diagnostic flag with real browser state check

### DIFF
--- a/src/components/ProfileScreen.tsx
+++ b/src/components/ProfileScreen.tsx
@@ -27,10 +27,10 @@ import { useProfileData } from '@/hooks/data/use-business-data'
 import { computeTrustScore } from '@/lib/trust-score'
 import type { UserAccount } from '@/lib/types'
 import {
-  getPushDiagnostic,
   requestPushPermissionFromUserGesture,
   isIosDevice,
   isRunningAsStandalonePwa,
+  isPushActuallyEnabled,
 } from '@/lib/push-notifications'
 
 interface Props {
@@ -150,12 +150,24 @@ export function ProfileScreen({
   const usernameInputRef = useRef<HTMLInputElement>(null)
   const [trustNudgeText, setTrustNudgeText] = useState('View your trust profile')
   const [trustScorePotential, setTrustScorePotential] = useState(0)
-  const [pushDiag, setPushDiag] = useState(getPushDiagnostic())
+  // null = initial check is in flight (don't render the banner yet — avoids flash)
+  // false = push is not set up → show banner
+  // true  = push is active → hide banner
+  const [pushEnabled, setPushEnabled] = useState<boolean | null>(null)
   const [enablingPush, setEnablingPush] = useState(false)
 
   useEffect(() => {
-    const interval = setInterval(() => setPushDiag(getPushDiagnostic()), 2000)
-    return () => clearInterval(interval)
+    let cancelled = false
+    isPushActuallyEnabled()
+      .then((enabled) => {
+        if (!cancelled) setPushEnabled(enabled)
+      })
+      .catch(() => {
+        if (!cancelled) setPushEnabled(false)
+      })
+    return () => {
+      cancelled = true
+    }
   }, [])
 
   useEffect(() => {
@@ -336,7 +348,7 @@ export function ProfileScreen({
       </div>
 
       {/* ── ENABLE NOTIFICATIONS BANNER ── */}
-      {!pushDiag.tokenSavedToDb && (
+      {pushEnabled === false && (
         <div style={{ padding: '0 14px 12px' }}>
           <div
             style={{
@@ -361,11 +373,11 @@ export function ProfileScreen({
                   setEnablingPush(true)
                   const result = await requestPushPermissionFromUserGesture(currentBusinessId)
                   setEnablingPush(false)
-                  setPushDiag(getPushDiagnostic())
-                  if (!result.ok) {
-                    toast.error(result.reason ?? 'Could not enable notifications')
-                  } else {
+                  if (result.ok) {
+                    setPushEnabled(true)
                     toast.success('Notifications enabled')
+                  } else {
+                    toast.error(result.reason ?? 'Could not enable notifications')
                   }
                 }}
                 disabled={enablingPush}

--- a/src/lib/push-notifications.ts
+++ b/src/lib/push-notifications.ts
@@ -360,6 +360,42 @@ function buffersEqual(a: ArrayBuffer, b: Uint8Array | ArrayBuffer): boolean {
 // ─── Public API ─────────────────────────────────────────────────────────────
 
 /**
+ * Returns true if push is actually set up right now, based on real browser
+ * state (not the in-memory diagnostic flag). Safe to call on every mount —
+ * the permission and subscription lookups are cheap.
+ *
+ * Use this instead of getPushDiagnostic().tokenSavedToDb to decide whether
+ * to show the "Enable notifications" banner. The diagnostic flag resets to
+ * false on every page load (module state is not persisted), while the real
+ * subscription persists across reloads in the browser.
+ */
+export async function isPushActuallyEnabled(): Promise<boolean> {
+  try {
+    if (Capacitor.isNativePlatform()) {
+      const status = await PushNotifications.checkPermissions()
+      return status.receive === 'granted'
+    }
+
+    if (!isPushSupported()) return false
+    if (typeof Notification === 'undefined') return false
+    if (Notification.permission !== 'granted') return false
+
+    // Permission alone is necessary but not sufficient — user might have
+    // revoked the subscription via browser settings, or the SW might have
+    // been unregistered. Check the actual PushSubscription exists.
+    if (!('serviceWorker' in navigator)) return false
+    const registration = await navigator.serviceWorker.ready
+    const subscription = await registration.pushManager.getSubscription()
+    return subscription !== null
+  } catch {
+    // Any failure (SW not ready, API access denied, etc.) → treat as not
+    // enabled. The banner will prompt the user; worst case is one extra
+    // tap on a functioning subscription, which is harmless.
+    return false
+  }
+}
+
+/**
  * Called at login (handleOTPSuccess). Does silent work only:
  * - On native: this IS safe to call — it triggers the system permission
  *   prompt which Android shows as a normal dialog.


### PR DESCRIPTION
## Summary
Replaced the in-memory `getPushDiagnostic()` flag with a new `isPushActuallyEnabled()` function that checks the actual browser state. This ensures the "Enable notifications" banner accurately reflects whether push notifications are truly set up, rather than relying on a module-level flag that resets on every page load.

## Key Changes
- **New function `isPushActuallyEnabled()`**: Async function that checks real browser state by:
  - On native platforms: checking Capacitor push notification permissions
  - On web: verifying Notification API permission AND actual PushSubscription existence via Service Worker
  - Gracefully returns `false` on any errors to avoid breaking the UI
  
- **Updated ProfileScreen banner logic**:
  - Changed `pushDiag` state from `getPushDiagnostic()` to `pushEnabled` with three states: `null` (loading), `false` (disabled), `true` (enabled)
  - Replaced polling interval with a single async check on mount
  - Added cancellation flag to prevent state updates after unmount
  - Updated banner visibility condition from `!pushDiag.tokenSavedToDb` to `pushEnabled === false`
  - Simplified post-enable logic: directly set `pushEnabled = true` instead of re-calling `getPushDiagnostic()`

## Implementation Details
- The new function is defensive: catches all exceptions and treats them as "not enabled" to avoid banner visibility issues
- Avoids the "flash" of the banner on mount by using `null` as the initial state
- The check is cheap (permission lookup + subscription query) and safe to call on every mount
- Maintains backward compatibility by keeping the old diagnostic function available

https://claude.ai/code/session_01AMK8L2RNt9dc9LS9bo2AeG