### PR TITLE
Add OrderDelivered notification type for order delivery tracking

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -975,7 +975,7 @@ function TabShell({
 }) {
   return (
     <>
-      <div className="flex-1 overflow-auto pb-16">
+      <div className="flex-1 overflow-auto pb-[calc(4rem+env(safe-area-inset-bottom))]">
         {activeTabScreen.tab === 'dashboard' ? (
           <DashboardScreen
             currentBusinessId={currentBusinessId}
@@ -1036,7 +1036,7 @@ function TabShell({
       </div>
 
       <div className="bottom-nav fixed bottom-0 left-0 right-0" style={{ backgroundColor: 'var(--bg-card)', borderTop: '1px solid var(--border-light)' }}>
-        <div className="flex items-center justify-around" style={{ paddingTop: '6px', paddingBottom: '4px' }}>
+        <div className="flex items-center justify-around" style={{ paddingTop: '6px', paddingBottom: 'calc(4px + env(safe-area-inset-bottom))' }}>
           <TabButton
             label="Home"
             Icon={House}

--- a/src/components/NotificationHistoryScreen.tsx
+++ b/src/components/NotificationHistoryScreen.tsx
@@ -27,6 +27,7 @@ interface Props {
 const ORDER_RELATED_NOTIFICATION_TYPES: NotificationType[] = [
   'OrderPlaced',
   'OrderDispatched',
+  'OrderDelivered',
   'OrderDeclined',
   'PaymentRecorded',
   'IssueRaised'

--- a/src/lib/interactions.ts
+++ b/src/lib/interactions.ts
@@ -257,6 +257,26 @@ export async function transitionOrderState(
       console.error('Notification failed:', err)
     }
   }
+  if (newState === 'Delivered') {
+    try {
+      const markedByBuyer = requestingBusinessId === connection.buyerBusinessId
+      const recipientId = markedByBuyer
+        ? connection.supplierBusinessId
+        : connection.buyerBusinessId
+      const actorName = markedByBuyer
+        ? await getOtherPartyName(connection.buyerBusinessId)
+        : await getOtherPartyName(connection.supplierBusinessId)
+      await dataStore.createNotification(
+        recipientId,
+        'OrderDelivered',
+        orderId,
+        order.connectionId,
+        formatNotificationMessage(order.itemSummary, `Delivered by ${actorName}`)
+      )
+    } catch (err) {
+      console.error('Notification failed:', err)
+    }
+  }
 
   await recalculateConnectionState(order.connectionId)
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -205,6 +205,7 @@ export type NotificationType =
   | 'OrderPlaced'
   | 'OrderAccepted'
   | 'OrderDispatched'
+  | 'OrderDelivered'
   | 'OrderDeclined'
   | 'PaymentRecorded'
   | 'PaymentDisputed'

--- a/supabase/functions/send-push/index.ts
+++ b/supabase/functions/send-push/index.ts
@@ -159,6 +159,7 @@ const NOTIFICATION_TITLES: Record<string, string> = {
   OrderPlaced: 'New Order',
   OrderAccepted: 'Order Accepted',
   OrderDispatched: 'Order Dispatched',
+  OrderDelivered: 'Order Delivered',
   OrderDeclined: 'Order Declined',
   PaymentRecorded: 'Payment Received',
   PaymentDisputed: 'Payment Disputed',

--- a/supabase/migrations/20260418000001_add_order_delivered_notification_type.sql
+++ b/supabase/migrations/20260418000001_add_order_delivered_notification_type.sql
@@ -1,0 +1,19 @@
+-- Add OrderDelivered to the notifications CHECK constraint.
+-- Already applied directly to production on 2026-04-18; this migration exists
+-- only so dev branches / future deploys stay in sync with production state.
+ALTER TABLE notifications DROP CONSTRAINT IF EXISTS notifications_type_check;
+ALTER TABLE notifications ADD CONSTRAINT notifications_type_check
+  CHECK (type IN (
+    'OrderPlaced',
+    'OrderAccepted',
+    'OrderDispatched',
+    'OrderDelivered',
+    'OrderDeclined',
+    'PaymentRecorded',
+    'PaymentDisputed',
+    'IssueRaised',
+    'IssueAcknowledged',
+    'IssueResolved',
+    'ConnectionAccepted',
+    'MemberJoined'
+  ));


### PR DESCRIPTION
## Summary
This PR adds support for notifying parties when an order has been marked as delivered. It introduces a new `OrderDelivered` notification type throughout the system and includes fixes for safe area insets on mobile devices.

## Key Changes
- **Notification Type Addition**: Added `OrderDelivered` as a new notification type in the type system and database constraints
- **Delivery Notification Logic**: Implemented notification creation when an order transitions to 'Delivered' state, notifying the other party (supplier or buyer) with the delivering party's name
- **Database Migration**: Added migration to update the notifications table CHECK constraint to include the new `OrderDelivered` type
- **UI Updates**: 
  - Updated `NotificationHistoryScreen` to include `OrderDelivered` in order-related notification types
  - Added push notification title mapping for `OrderDelivered`
  - Fixed safe area inset handling in bottom navigation for mobile devices with notches/safe areas
- **Type Definitions**: Updated `NotificationType` union type to include the new notification type

## Implementation Details
- The delivery notification is sent to the opposite party (if buyer marks as delivered, supplier is notified, and vice versa)
- The notification message includes the delivering party's name via `getOtherPartyName()` lookup
- Safe area inset fixes use CSS `env(safe-area-inset-bottom)` to properly account for device notches and home indicators on mobile
- Database migration includes a note that the constraint was already applied to production; this ensures dev branches stay in sync

https://claude.ai/code/session_01UZ2LsjnUaoGKaePMMnkDLt