### PR TITLE
Fix safe area inset handling and bump version to 1.0.10

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -6,8 +6,8 @@ android {
         applicationId "com.zeltoapp.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 9
-        versionName "1.0.9"
+        versionCode 10
+        versionName "1.0.10"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
             ignoreAssetsPattern '!.svn:!.git:!.ds_store:!*.scc:.*:!CVS:!thumbs.db:!picasa.ini:!*~'

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -7,6 +7,9 @@ const config: CapacitorConfig = {
   server: {
     androidScheme: 'https',
   },
+  android: {
+    adjustMarginsForEdgeToEdge: 'never',
+  },
   plugins: {
     SplashScreen: {
       launchShowDuration: 2000,

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="viewport" content="viewport-fit=cover, width=device-width, initial-scale=1.0" />
     <title>Zelto</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1036,7 +1036,7 @@ function TabShell({
       </div>
 
       <div className="bottom-nav fixed bottom-0 left-0 right-0" style={{ backgroundColor: 'var(--bg-card)', borderTop: '1px solid var(--border-light)' }}>
-        <div className="flex items-center justify-around" style={{ paddingTop: '6px', paddingBottom: 'calc(4px + env(safe-area-inset-bottom))' }}>
+        <div className="flex items-center justify-around" style={{ paddingTop: '6px', paddingBottom: 'env(safe-area-inset-bottom, 16px)' }}>
           <TabButton
             label="Home"
             Icon={House}

--- a/src/index.css
+++ b/src/index.css
@@ -142,7 +142,7 @@ html, body, #root {
 }
 
 .bottom-nav {
-  padding-bottom: calc(4px + env(safe-area-inset-bottom));
+  padding-bottom: env(safe-area-inset-bottom, 16px);
 }
 
 /* ── Micro-interaction animations ────────────────────────────────── */


### PR DESCRIPTION
## Summary
This PR addresses safe area inset handling for edge-to-edge display support on Android, updates the app version, and refines viewport configuration for better notch/cutout compatibility.

## Key Changes
- **Version bump**: Updated versionCode from 9 to 10 and versionName to "1.0.10"
- **Safe area inset fixes**: 
  - Simplified bottom navigation padding calculation from `calc(4px + env(safe-area-inset-bottom))` to `env(safe-area-inset-bottom, 16px)` with a sensible fallback
  - Applied the same fix in both `src/App.tsx` and `src/index.css` for consistency
- **Android edge-to-edge configuration**: Added `adjustMarginsForEdgeToEdge: 'never'` to Capacitor config to prevent automatic margin adjustments
- **Viewport meta tag reordering**: Reordered viewport meta attributes in `index.html` to place `viewport-fit=cover` first for better notch/cutout handling

## Implementation Details
The safe area inset changes ensure proper spacing on devices with notches, Dynamic Island, or other display cutouts. The fallback value of 16px provides a reasonable default for browsers/devices that don't support the `env()` function. The Capacitor configuration change gives the app explicit control over edge-to-edge layout behavior rather than relying on automatic adjustments.

https://claude.ai/code/session_01G6WBHih8zUD6d4aPYPDtzz