### PR TITLE
Bump version to 1.0.11 and improve bottom nav safe area handling

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -6,8 +6,8 @@ android {
         applicationId "com.zeltoapp.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 10
-        versionName "1.0.10"
+        versionCode 11
+        versionName "1.0.11"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
             ignoreAssetsPattern '!.svn:!.git:!.ds_store:!*.scc:.*:!CVS:!thumbs.db:!picasa.ini:!*~'

--- a/src/index.css
+++ b/src/index.css
@@ -142,7 +142,7 @@ html, body, #root {
 }
 
 .bottom-nav {
-  padding-bottom: env(safe-area-inset-bottom, 16px);
+  padding-bottom: max(env(safe-area-inset-bottom), 24px);
 }
 
 /* ── Micro-interaction animations ────────────────────────────────── */


### PR DESCRIPTION
## Summary
This release includes a version bump and an improvement to the bottom navigation safe area inset handling for better mobile device compatibility.

## Key Changes
- **Version bump**: Updated Android app version from 1.0.10 to 1.0.11 (versionCode 10 → 11)
- **Bottom navigation safe area**: Changed padding calculation from `env(safe-area-inset-bottom, 16px)` to `max(env(safe-area-inset-bottom), 24px)` to ensure a minimum padding of 24px while respecting device safe area insets

## Implementation Details
The bottom navigation padding improvement ensures that:
- Devices with notches, home indicators, or other safe area constraints are properly respected
- A minimum padding of 24px is maintained even on devices without safe area insets
- The navigation remains accessible and properly spaced across all device types

https://claude.ai/code/session_01R6i68EPi9fAzHUAxGfPQzo