### PR TITLE
Bump version to 1.0.12 and adjust edge-to-edge display

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -6,8 +6,8 @@ android {
         applicationId "com.zeltoapp.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 11
-        versionName "1.0.11"
+        versionCode 12
+        versionName "1.0.12"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
             ignoreAssetsPattern '!.svn:!.git:!.ds_store:!*.scc:.*:!CVS:!thumbs.db:!picasa.ini:!*~'

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -8,7 +8,7 @@ const config: CapacitorConfig = {
     androidScheme: 'https',
   },
   android: {
-    adjustMarginsForEdgeToEdge: 'never',
+    adjustMarginsForEdgeToEdge: 'auto',
   },
   plugins: {
     SplashScreen: {

--- a/src/index.css
+++ b/src/index.css
@@ -142,7 +142,7 @@ html, body, #root {
 }
 
 .bottom-nav {
-  padding-bottom: max(env(safe-area-inset-bottom), 24px);
+  padding-bottom: 0px;
 }
 
 /* ── Micro-interaction animations ────────────────────────────────── */


### PR DESCRIPTION
## Summary
This release updates the app version and adjusts the Android edge-to-edge display configuration along with related UI padding changes.

## Key Changes
- **Version bump**: Updated versionCode from 11 to 12 and versionName from "1.0.11" to "1.0.12"
- **Edge-to-edge display**: Changed `adjustMarginsForEdgeToEdge` from `'never'` to `'auto'` in Capacitor Android configuration to enable automatic edge-to-edge layout handling
- **Bottom navigation padding**: Removed safe area inset padding from `.bottom-nav` by changing from `max(env(safe-area-inset-bottom), 24px)` to `0px` to accommodate the edge-to-edge display mode

## Implementation Details
The edge-to-edge display change allows the app to extend content to the screen edges on supported Android devices. The bottom navigation padding adjustment ensures proper spacing when edge-to-edge mode is active, preventing overlap with system UI elements.

https://claude.ai/code/session_01K2VZrpAaLHLkPHEvNt5aV6