### PR TITLE
Bump version to 1.0.13 and update launcher background color

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -6,8 +6,8 @@ android {
         applicationId "com.zeltoapp.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 12
-        versionName "1.0.12"
+        versionCode 13
+        versionName "1.0.13"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
             ignoreAssetsPattern '!.svn:!.git:!.ds_store:!*.scc:.*:!CVS:!thumbs.db:!picasa.ini:!*~'

--- a/android/app/src/main/res/values/ic_launcher_background.xml
+++ b/android/app/src/main/res/values/ic_launcher_background.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="ic_launcher_background">#ffffff</color>
+    <color name="ic_launcher_background">#1A56DB</color>
 </resources>


### PR DESCRIPTION
## Summary
This release updates the app version and refreshes the app launcher icon background color to match the updated design system.

## Key Changes
- Bumped version code from 12 to 13 and version name from 1.0.12 to 1.0.13
- Updated `ic_launcher_background` color from white (#ffffff) to primary blue (#1A56DB)

## Details
The launcher background color change aligns the app icon with the primary brand color, providing a more cohesive visual identity across the application.

https://claude.ai/code/session_01Vg1tgZmfuyPSCex9fFBHJo